### PR TITLE
FTD grid

### DIFF
--- a/examples/grid-sample.ftd
+++ b/examples/grid-sample.ftd
@@ -1,0 +1,29 @@
+-- ftd.column:
+padding: 30
+
+
+-- ftd.grid:
+slots: header header | sidebar main
+slot-widths: 60px 100px
+slot-heights: 20px 200px
+background-color: #2196F3
+spacing: 10
+padding: 10
+
+--- text: Header
+slot: header
+
+--- text: Sidebar
+slot: sidebar
+
+--- text: Main
+slot: main
+
+
+-- ftd.text text: $value
+caption value:
+string slot:
+slot: $slot
+background-color: rgba(255, 255, 255, 0.8)
+text-align: center
+height: fill

--- a/examples/grid-sample.ftd
+++ b/examples/grid-sample.ftd
@@ -1,24 +1,36 @@
+-- boolean mobile: false
+
 -- ftd.column:
 padding: 30
 
 
 -- ftd.grid:
 slots: header header | sidebar main
+slots if $mobile: header | main
 slot-widths: 60px 100px
+slot-widths if $mobile : 60px
 slot-heights: 20px 200px
+slot-heights if $mobile: 20px 100px
 background-color: #2196F3
 spacing: 10
+spacing if $mobile: 5
 padding: 10
 
 --- text: Header
 slot: header
+slot if $mobile: main
 
 --- text: Sidebar
+if: not $mobile
 slot: sidebar
 
 --- text: Main
 slot: main
+slot if $mobile: header
 
+
+-- ftd.text: CLICK HERE!
+$event-click$: toggle $mobile
 
 -- ftd.text text: $value
 caption value:

--- a/examples/grid.ftd
+++ b/examples/grid.ftd
@@ -11,22 +11,22 @@ width: fill
 This grid layout contains six columns and three rows:
 
 -- ftd.grid:
-areas: header header header header header header | menu main main main right right | menu footer footer footer footer footer
-gap: 10
+slots: header header header header header header | menu main main main right right | menu footer footer footer footer footer
+spacing: 10
 background-color: #2196F3
 padding: 10
 width: fill
 margin-bottom: 40
 
 --- ftd.text: Header
-grid-area: header
+slot: header
 background-color: rgba(255, 255, 255, 0.8)
 text-align: center
 size: 30
 padding-vertical: 20
 
 --- ftd.text: Menu
-grid-area: menu
+slot: menu
 background-color: rgba(255, 255, 255, 0.8)
 text-align: center
 size: 30
@@ -34,21 +34,21 @@ padding-vertical: 20
 height: fill
 
 --- ftd.text: Main
-grid-area: main
+slot: main
 background-color: rgba(255, 255, 255, 0.8)
 text-align: center
 size: 30
 padding-vertical: 20
 
 --- ftd.text: Right
-grid-area: right
+slot: right
 background-color: rgba(255, 255, 255, 0.8)
 text-align: center
 size: 30
 padding-vertical: 20
 
 --- ftd.text: Footer
-grid-area: footer
+slot: footer
 background-color: rgba(255, 255, 255, 0.8)
 text-align: center
 size: 30
@@ -56,11 +56,11 @@ padding-vertical: 20
 
 
 
--- ft.h1: Grid Using Rows and Column
+/-- ft.h1: Grid Using Rows and Column
 
 This grid layout contains three columns and two rows:
 
--- ftd.grid:
+/-- ftd.grid:
 columns: 100px 50px 100px
 rows: 80px auto
 column-gap: 10
@@ -123,36 +123,36 @@ padding-vertical: 20
 This grid layout contains four columns and three rows:
 
 -- ftd.grid:
-areas: header header header header | main main . sidebar | footer footer footer footer
-gap: 10
+slots: header header header header | main main . sidebar | footer footer footer footer
+spacing: 10
 background-color: green
 padding: 10
 width: fill
 margin-bottom: 40
 
 --- ftd.text: Header
-grid-area: header
+slot: header
 background-color: rgba(255, 255, 255, 0.8)
 text-align: center
 size: 30
 padding-vertical: 20
 
 --- ftd.text: Main
-grid-area: main
+slot: main
 background-color: rgba(255, 255, 255, 0.8)
 text-align: center
 size: 30
 padding-vertical: 20
 
 --- ftd.text: Sidebar
-grid-area: sidebar
+slot: sidebar
 background-color: rgba(255, 255, 255, 0.8)
 text-align: center
 size: 30
 padding-vertical: 20
 
 --- ftd.text: Footer
-grid-area: footer
+slot: footer
 background-color: rgba(255, 255, 255, 0.8)
 text-align: center
 size: 30
@@ -160,11 +160,11 @@ padding-vertical: 20
 
 
 
--- ft.h1: Grid Row Auto Flow
+/-- ft.h1: Grid Row Auto Flow
 
 This grid layout contains five columns and two rows:
 
--- ftd.grid:
+/-- ftd.grid:
 columns: 60px 60px 60px 60px 60px
 rows: 30px 30px
 column-gap: 10
@@ -214,11 +214,11 @@ height: fill
 overflow-y: auto
 
 
--- ft.h1: Grid Column Auto Flow
+/-- ft.h1: Grid Column Auto Flow
 
 This grid layout contains five columns and two rows:
 
--- ftd.grid:
+/-- ftd.grid:
 columns: 60px 60px 60px 60px 60px
 rows: 30px 30px
 column-gap: 10
@@ -266,3 +266,33 @@ text-align: center
 size: 30
 height: fill
 overflow-y: auto
+
+-- ft.h1: Grid Areas with slot-widths and slot-heights
+
+This grid layout contains two columns and two rows:
+
+-- ftd.grid:
+slots: header header | sidebar main
+slot-widths: 60px 100px
+slot-heights: 20px 200px
+background-color: #2196F3
+spacing: 10
+padding: 10
+
+--- text: Header
+slot: header
+
+--- text: Sidebar
+slot: sidebar
+
+--- text: Main
+slot: main
+
+
+-- ftd.text text: $value
+caption value:
+string slot:
+slot: $slot
+background-color: rgba(255, 255, 255, 0.8)
+text-align: center
+height: fill

--- a/examples/grid.ftd
+++ b/examples/grid.ftd
@@ -1,0 +1,53 @@
+-- import: ft
+
+-- ftd.column:
+padding: 30
+width: fill
+
+-- ft.h0: Grid Layout
+
+This grid layout contains six columns and three rows:
+
+-- ftd.grid:
+areas: header header header header header header | menu main main main right right | menu footer footer footer footer footer
+gap: 10
+background-color: #2196F3
+padding: 10
+width: fill
+
+--- ftd.text: Header
+grid-area: header
+background-color: rgba(255, 255, 255, 0.8)
+text-align: center
+size: 30
+padding-vertical: 20
+
+--- ftd.text: Menu
+grid-area: menu
+background-color: rgba(255, 255, 255, 0.8)
+text-align: center
+size: 30
+padding-vertical: 20
+height: fill
+
+--- ftd.text: Main
+grid-area: main
+background-color: rgba(255, 255, 255, 0.8)
+text-align: center
+size: 30
+padding-vertical: 20
+
+--- ftd.text: Right
+grid-area: right
+background-color: rgba(255, 255, 255, 0.8)
+text-align: center
+size: 30
+padding-vertical: 20
+
+--- ftd.text: Footer
+grid-area: footer
+background-color: rgba(255, 255, 255, 0.8)
+text-align: center
+size: 30
+padding-vertical: 20
+

--- a/examples/grid.ftd
+++ b/examples/grid.ftd
@@ -1,5 +1,8 @@
 -- import: ft
 
+-- boolean mobile: false
+
+
 -- ftd.column:
 padding: 30
 width: fill
@@ -275,7 +278,7 @@ This grid layout contains two columns and two rows:
 slots: header header | sidebar main
 slot-widths: 60px 100px
 slot-heights: 20px 200px
-background-color: #2196F3
+background-color: purple
 spacing: 10
 padding: 10
 
@@ -288,6 +291,46 @@ slot: sidebar
 --- text: Main
 slot: main
 
+
+-- ftd.text text: $value
+caption value:
+string slot:
+slot: $slot
+background-color: rgba(255, 255, 255, 0.8)
+text-align: center
+height: fill
+
+-- ft.h1: Grid with Event
+
+This grid layout contains two columns and two rows which changes to one column and two rows:
+
+-- ftd.grid:
+slots: header header | sidebar main
+slots if $mobile: header | main
+slot-widths: 60px 100px
+slot-widths if $mobile : 60px
+slot-heights: 20px 200px
+slot-heights if $mobile: 20px 100px
+background-color: #2196F3
+spacing: 10
+spacing if $mobile: 5
+padding: 10
+
+--- text: Header
+slot: header
+slot if $mobile: main
+
+--- text: Sidebar
+if: not $mobile
+slot: sidebar
+
+--- text: Main
+slot: main
+slot if $mobile: header
+
+
+-- ftd.text: CLICK HERE!
+$event-click$: toggle $mobile
 
 -- ftd.text text: $value
 caption value:

--- a/examples/grid.ftd
+++ b/examples/grid.ftd
@@ -116,3 +116,42 @@ text-align: center
 size: 30
 padding-vertical: 20
 
+-- ft.h1: Grid Using Area With An Empty Grid Cell
+
+This grid layout contains four columns and three rows:
+
+-- ftd.grid:
+areas: header header header header | main main . sidebar | footer footer footer footer
+gap: 10
+background-color: green
+padding: 10
+width: fill
+margin-bottom: 40
+
+--- ftd.text: Header
+grid-area: header
+background-color: rgba(255, 255, 255, 0.8)
+text-align: center
+size: 30
+padding-vertical: 20
+
+--- ftd.text: Main
+grid-area: main
+background-color: rgba(255, 255, 255, 0.8)
+text-align: center
+size: 30
+padding-vertical: 20
+
+--- ftd.text: Sidebar
+grid-area: sidebar
+background-color: rgba(255, 255, 255, 0.8)
+text-align: center
+size: 30
+padding-vertical: 20
+
+--- ftd.text: Footer
+grid-area: footer
+background-color: rgba(255, 255, 255, 0.8)
+text-align: center
+size: 30
+padding-vertical: 20

--- a/examples/grid.ftd
+++ b/examples/grid.ftd
@@ -6,6 +6,8 @@ width: fill
 
 -- ft.h0: Grid Layout
 
+-- ft.h1: Grid Using Area
+
 This grid layout contains six columns and three rows:
 
 -- ftd.grid:
@@ -14,6 +16,7 @@ gap: 10
 background-color: #2196F3
 padding: 10
 width: fill
+margin-bottom: 40
 
 --- ftd.text: Header
 grid-area: header
@@ -46,6 +49,68 @@ padding-vertical: 20
 
 --- ftd.text: Footer
 grid-area: footer
+background-color: rgba(255, 255, 255, 0.8)
+text-align: center
+size: 30
+padding-vertical: 20
+
+-- ft.h1: Grid Using Rows and Column
+
+This grid layout contains three columns and two rows:
+
+-- ftd.grid:
+columns: 100px 50px 100px
+rows: 80px auto
+column-gap: 10
+row-gap: 15
+background-color: red
+padding: 10
+margin-bottom: 40
+
+--- ftd.text: 11
+grid-column: 1 / 2
+grid-row: 1 / 2
+background-color: rgba(255, 255, 255, 0.8)
+text-align: center
+size: 30
+padding-vertical: 20
+
+--- ftd.text: 12
+grid-column: 2 / 3
+grid-row: 1 / 2
+background-color: rgba(255, 255, 255, 0.8)
+text-align: center
+size: 30
+padding-vertical: 20
+height: fill
+
+--- ftd.text: 13
+grid-column: 3 / 4
+grid-row: 1 / 2
+background-color: rgba(255, 255, 255, 0.8)
+text-align: center
+size: 30
+padding-vertical: 20
+
+--- ftd.text: 21
+grid-column: 1 / 2
+grid-row: 2 / 3
+background-color: rgba(255, 255, 255, 0.8)
+text-align: center
+size: 30
+padding-vertical: 20
+
+--- ftd.text: 22
+grid-column: 2 / 3
+grid-row: 2 / 3
+background-color: rgba(255, 255, 255, 0.8)
+text-align: center
+size: 30
+padding-vertical: 20
+
+--- ftd.text: 23
+grid-column: 3 / 4
+grid-row: 2 / 3
 background-color: rgba(255, 255, 255, 0.8)
 text-align: center
 size: 30

--- a/examples/grid.ftd
+++ b/examples/grid.ftd
@@ -54,6 +54,8 @@ text-align: center
 size: 30
 padding-vertical: 20
 
+
+
 -- ft.h1: Grid Using Rows and Column
 
 This grid layout contains three columns and two rows:
@@ -155,3 +157,112 @@ background-color: rgba(255, 255, 255, 0.8)
 text-align: center
 size: 30
 padding-vertical: 20
+
+
+
+-- ft.h1: Grid Row Auto Flow
+
+This grid layout contains five columns and two rows:
+
+-- ftd.grid:
+columns: 60px 60px 60px 60px 60px
+rows: 30px 30px
+column-gap: 10
+row-gap: 15
+background-color: red
+padding: 10
+margin-bottom: 40
+auto-flow: row
+
+--- ftd.text: 11
+grid-column: 1
+grid-row: 1 / 3
+background-color: rgba(255, 255, 255, 0.8)
+text-align: center
+size: 30
+height: fill
+overflow-y: auto
+
+--- ftd.text: 12
+background-color: rgba(255, 255, 255, 0.8)
+text-align: center
+size: 30
+height: fill
+overflow-y: auto
+
+--- ftd.text: 13
+background-color: rgba(255, 255, 255, 0.8)
+text-align: center
+size: 30
+height: fill
+overflow-y: auto
+
+--- ftd.text: 14
+background-color: rgba(255, 255, 255, 0.8)
+text-align: center
+size: 30
+height: fill
+overflow-y: auto
+
+--- ftd.text: 15
+grid-column: 5
+grid-row: 1 / 3
+background-color: rgba(255, 255, 255, 0.8)
+text-align: center
+size: 30
+height: fill
+overflow-y: auto
+
+
+-- ft.h1: Grid Column Auto Flow
+
+This grid layout contains five columns and two rows:
+
+-- ftd.grid:
+columns: 60px 60px 60px 60px 60px
+rows: 30px 30px
+column-gap: 10
+row-gap: 15
+background-color: red
+padding: 10
+margin-bottom: 40
+auto-flow: column
+
+--- ftd.text: 11
+grid-column: 1
+grid-row: 1 / 3
+background-color: rgba(255, 255, 255, 0.8)
+text-align: center
+size: 30
+height: fill
+overflow-y: auto
+
+--- ftd.text: 12
+background-color: rgba(255, 255, 255, 0.8)
+text-align: center
+size: 30
+height: fill
+overflow-y: auto
+
+--- ftd.text: 13
+background-color: rgba(255, 255, 255, 0.8)
+text-align: center
+size: 30
+height: fill
+overflow-y: auto
+
+--- ftd.text: 14
+background-color: rgba(255, 255, 255, 0.8)
+text-align: center
+size: 30
+height: fill
+overflow-y: auto
+
+--- ftd.text: 15
+grid-column: 5
+grid-row: 1 / 3
+background-color: rgba(255, 255, 255, 0.8)
+text-align: center
+size: 30
+height: fill
+overflow-y: auto

--- a/src/component.rs
+++ b/src/component.rs
@@ -182,7 +182,8 @@ impl ChildComponent {
         match (&mut element, children.is_empty()) {
             (ftd::Element::Column(_), _)
             | (ftd::Element::Row(_), _)
-            | (ftd::Element::Scene(_), _) => {
+            | (ftd::Element::Scene(_), _)
+            | (ftd::Element::Grid(_), _) => {
                 let instructions = children
                     .iter()
                     .map(|child| {
@@ -220,7 +221,7 @@ impl ChildComponent {
                         .unwrap();
                 }
                 match root.full_name.as_str() {
-                    "ftd#row" | "ftd#column" | "ftd#scene" => {}
+                    "ftd#row" | "ftd#column" | "ftd#scene" | "ftd#grid" => {}
                     t => {
                         return ftd::e2(
                             format!("{} cant have children", t),
@@ -1250,6 +1251,9 @@ impl Component {
                 "ftd#scene" => ftd::Element::Scene(ftd::p2::element::scene_from_properties(
                     arguments, doc, condition, is_child, events, all_locals, root_name,
                 )?),
+                "ftd#grid" => ftd::Element::Grid(ftd::p2::element::grid_from_properties(
+                    arguments, doc, condition, is_child, events, all_locals, root_name,
+                )?),
                 _ => unreachable!(),
             };
             Ok(ElementWithContainer {
@@ -1395,6 +1399,9 @@ impl Component {
                     ref mut container, ..
                 })
                 | ftd::Element::Scene(ftd::Scene {
+                    ref mut container, ..
+                })
+                | ftd::Element::Grid(ftd::Grid {
                     ref mut container, ..
                 }) => {
                     let ElementWithContainer {
@@ -1758,7 +1765,8 @@ fn is_component(name: &str) -> bool {
         || (name == "ftd.decimal")
         || (name == "ftd.boolean")
         || (name == "ftd.input")
-        || (name == "ftd.scene"))
+        || (name == "ftd.scene")
+        || (name == "ftd.grid"))
 }
 
 fn assert_no_extra_properties(

--- a/src/component.rs
+++ b/src/component.rs
@@ -684,6 +684,20 @@ fn get_conditional_attributes(
         ],
     );
 
+    dictionary.insert("slots".to_string(), vec!["grid-template-areas".to_string()]);
+    dictionary.insert(
+        "slot-widths".to_string(),
+        vec!["grid-template-columns".to_string()],
+    );
+    dictionary.insert(
+        "slot-heights".to_string(),
+        vec!["grid-template-rows".to_string()],
+    );
+    if properties.contains_key("slots") {
+        dictionary.insert("spacing".to_string(), vec!["grid-gap".to_string()]);
+    }
+    dictionary.insert("slot".to_string(), vec!["grid-area".to_string()]);
+
     for (name, value) in properties {
         if !value.conditions.is_empty() {
             let styles = if let Some(styles) = dictionary.get(name) {
@@ -764,6 +778,7 @@ fn get_conditional_attributes(
             "shadow-blur",
             "font-size",
             "border-width",
+            "grid-gap",
         ];
 
         let style_length = vec![
@@ -788,7 +803,15 @@ fn get_conditional_attributes(
             "border-bottom-right-radius",
         ];
 
-        let style_string = vec!["cursor", "position", "align", "background-image"];
+        let style_string = vec![
+            "cursor",
+            "position",
+            "align",
+            "background-image",
+            "grid-template-columns",
+            "grid-template-rows",
+            "grid-area",
+        ];
 
         let style_overflow = vec!["overflow-x", "overflow-y"];
 
@@ -915,6 +938,27 @@ fn get_conditional_attributes(
                     important: false,
                 },
                 v => return ftd::e2(format!("expected int, found: {:?}", v), doc_id, line_number),
+            }
+        } else if name.eq("grid-template-areas") {
+            match value {
+                ftd::Value::String { text: v, .. } => {
+                    let areas = v.split('|').map(|v| v.trim()).collect::<Vec<&str>>();
+                    let mut css_areas = "".to_string();
+                    for area in areas {
+                        css_areas = format!("{}'{}'", css_areas, area);
+                    }
+                    ftd::ConditionalValue {
+                        value: css_areas,
+                        important: false,
+                    }
+                }
+                v => {
+                    return ftd::e2(
+                        format!("expected string, found: {:?}", v),
+                        doc_id,
+                        line_number,
+                    )
+                }
             }
         } else {
             return ftd::e2(

--- a/src/execute_doc.rs
+++ b/src/execute_doc.rs
@@ -54,6 +54,7 @@ impl<'a> ExecuteDoc<'a> {
                             ftd::Element::Row(ref r) => &r.container.children,
                             ftd::Element::Column(ref r) => &r.container.children,
                             ftd::Element::Scene(ref r) => &r.container.children,
+                            ftd::Element::Grid(ref r) => &r.container.children,
                             _ => unreachable!(),
                         };
                     }
@@ -238,6 +239,7 @@ impl<'a> ExecuteDoc<'a> {
                 ftd::Element::Row(ref mut r) => &mut r.container.children,
                 ftd::Element::Column(ref mut r) => &mut r.container.children,
                 ftd::Element::Scene(ref mut r) => &mut r.container.children,
+                ftd::Element::Grid(ref mut r) => &mut r.container.children,
                 _ => unreachable!(),
             };
         }
@@ -291,6 +293,10 @@ impl<'a> ExecuteDoc<'a> {
                 | Some(ftd::Element::Scene(ftd::Scene {
                     container: ref mut c,
                     ..
+                }))
+                | Some(ftd::Element::Grid(ftd::Grid {
+                    container: ref mut c,
+                    ..
                 })) => {
                     let child = if container_children.is_empty() {
                         current_container.push(len);
@@ -335,6 +341,9 @@ impl<'a> ExecuteDoc<'a> {
                     ref mut container, ..
                 }))
                 | Some(ftd::Element::Scene(ftd::Scene {
+                    ref mut container, ..
+                }))
+                | Some(ftd::Element::Grid(ftd::Grid {
                     ref mut container, ..
                 })) => {
                     container.children.extend(container_children);

--- a/src/html.rs
+++ b/src/html.rs
@@ -471,7 +471,39 @@ impl ftd::Scene {
 
 impl ftd::Grid {
     pub fn to_node(&self, doc_id: &str) -> Node {
-        Node::from_container(&self.common, &self.container, doc_id)
+        let mut n = Node::from_container(&self.common, &self.container, doc_id);
+        if self.inline {
+            n.style.insert(s("display"), s("inline-grid"));
+        } else {
+            n.style.insert(s("display"), s("grid"));
+        }
+        if let Some(ref areas) = self.areas {
+            let areas = areas.split('|').map(|v| v.trim()).collect::<Vec<&str>>();
+            let mut css_areas = s("");
+            for area in areas {
+                css_areas = format!("{}'{}'", css_areas, area);
+            }
+            n.style.insert(s("grid-template-areas"), css_areas);
+        }
+        if let Some(ref columns) = self.columns {
+            n.style.insert(s("grid-template-columns"), s(columns));
+        }
+        if let Some(ref columns) = self.columns {
+            n.style.insert(s("grid-template-columns"), s(columns));
+        }
+        if let Some(ref rows) = self.rows {
+            n.style.insert(s("grid-template-rows"), s(rows));
+        }
+        if let Some(ref gap) = self.gap {
+            n.style.insert(s("grid-gap"), format!("{}px", gap));
+        }
+        if let Some(ref gap) = self.column_gap {
+            n.style.insert(s("column-gap"), format!("{}px", gap));
+        }
+        if let Some(ref gap) = self.row_gap {
+            n.style.insert(s("row-gap"), format!("{}px", gap));
+        }
+        n
     }
 }
 
@@ -949,6 +981,15 @@ impl ftd::Common {
         }
         if let Some(p) = &self.z_index {
             d.insert(s("z-index"), format!("{}px", p));
+        }
+        if let Some(p) = &self.grid_area {
+            d.insert(s("grid-area"), s(p));
+        }
+        if let Some(p) = &self.grid_column {
+            d.insert(s("grid-column"), s(p));
+        }
+        if let Some(p) = &self.grid_row {
+            d.insert(s("grid-row"), s(p));
         }
         if self.shadow_size.is_some()
             || self.shadow_blur.is_some()

--- a/src/html.rs
+++ b/src/html.rs
@@ -503,6 +503,9 @@ impl ftd::Grid {
         if let Some(ref gap) = self.row_gap {
             n.style.insert(s("row-gap"), format!("{}px", gap));
         }
+        if let Some(ref auto_flow) = self.auto_flow {
+            n.style.insert(s("grid-auto-flow"), s(auto_flow));
+        }
         n
     }
 }

--- a/src/html.rs
+++ b/src/html.rs
@@ -251,6 +251,7 @@ impl ftd::Element {
         match self {
             Self::Row(i) => (i.to_node(doc_id)),
             Self::Scene(i) => (i.to_node(doc_id)),
+            Self::Grid(i) => (i.to_node(doc_id)),
             Self::Text(i) => (i.to_node(doc_id)),
             Self::TextBlock(i) => (i.to_node(doc_id)),
             Self::Code(i) => (i.to_node(doc_id)),
@@ -465,6 +466,12 @@ impl ftd::Scene {
         }
         main_node.children = vec![node];
         main_node
+    }
+}
+
+impl ftd::Grid {
+    pub fn to_node(&self, doc_id: &str) -> Node {
+        Node::from_container(&self.common, &self.container, doc_id)
     }
 }
 

--- a/src/html.rs
+++ b/src/html.rs
@@ -489,10 +489,11 @@ impl ftd::Grid {
         n.style.insert(s("grid-template-areas"), css_areas);
 
         if let Some(ref columns) = self.slot_widths {
-            n.style.insert(s("grid-template-columns"), s(columns));
+            n.style
+                .insert(s("grid-template-columns"), s(columns.trim()));
         }
         if let Some(ref rows) = self.slot_heights {
-            n.style.insert(s("grid-template-rows"), s(rows));
+            n.style.insert(s("grid-template-rows"), s(rows.trim()));
         }
         if let Some(ref gap) = self.spacing {
             n.style.insert(s("grid-gap"), format!("{}px", gap));
@@ -985,7 +986,7 @@ impl ftd::Common {
         if let Some(p) = &self.z_index {
             d.insert(s("z-index"), format!("{}px", p));
         }
-        if let Some(p) = &self.grid_area {
+        if let Some(p) = &self.slot {
             d.insert(s("grid-area"), s(p));
         }
         if let Some(p) = &self.grid_column {

--- a/src/html.rs
+++ b/src/html.rs
@@ -452,7 +452,7 @@ impl ftd::Scene {
         if self.common.width.is_none() {
             main_node.style.insert(s("width"), s("1000px"));
         }
-        if let Some(ref p) = self.container.spacing {
+        if let Some(ref p) = self.spacing {
             let (key, value) = spacing(p, "margin-left");
             match p {
                 ftd::Spacing::Absolute { value } => {
@@ -477,30 +477,30 @@ impl ftd::Grid {
         } else {
             n.style.insert(s("display"), s("grid"));
         }
-        if let Some(ref areas) = self.areas {
-            let areas = areas.split('|').map(|v| v.trim()).collect::<Vec<&str>>();
-            let mut css_areas = s("");
-            for area in areas {
-                css_areas = format!("{}'{}'", css_areas, area);
-            }
-            n.style.insert(s("grid-template-areas"), css_areas);
+        let areas = self
+            .slots
+            .split('|')
+            .map(|v| v.trim())
+            .collect::<Vec<&str>>();
+        let mut css_areas = s("");
+        for area in areas {
+            css_areas = format!("{}'{}'", css_areas, area);
         }
-        if let Some(ref columns) = self.columns {
+        n.style.insert(s("grid-template-areas"), css_areas);
+
+        if let Some(ref columns) = self.slot_widths {
             n.style.insert(s("grid-template-columns"), s(columns));
         }
-        if let Some(ref columns) = self.columns {
-            n.style.insert(s("grid-template-columns"), s(columns));
-        }
-        if let Some(ref rows) = self.rows {
+        if let Some(ref rows) = self.slot_heights {
             n.style.insert(s("grid-template-rows"), s(rows));
         }
-        if let Some(ref gap) = self.gap {
+        if let Some(ref gap) = self.spacing {
             n.style.insert(s("grid-gap"), format!("{}px", gap));
         }
-        if let Some(ref gap) = self.column_gap {
+        if let Some(ref gap) = self.spacing_vertical {
             n.style.insert(s("column-gap"), format!("{}px", gap));
         }
-        if let Some(ref gap) = self.row_gap {
+        if let Some(ref gap) = self.spacing_horizontal {
             n.style.insert(s("row-gap"), format!("{}px", gap));
         }
         if let Some(ref auto_flow) = self.auto_flow {
@@ -527,7 +527,7 @@ impl ftd::Row {
 
         n.style.insert(s("justify-content"), s("flex-start"));
 
-        if let Some(ref p) = self.container.spacing {
+        if let Some(ref p) = self.spacing {
             let (key, value) = spacing(p, "margin-left");
             match p {
                 ftd::Spacing::Absolute { value } => {
@@ -559,7 +559,7 @@ impl ftd::Column {
 
         n.style.insert(s("justify-content"), s("flex-start"));
 
-        if let Some(ref p) = self.container.spacing {
+        if let Some(ref p) = self.spacing {
             let (key, value) = spacing(p, "margin-top");
             match p {
                 ftd::Spacing::Absolute { value } => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,9 +30,9 @@ pub use or_type::OrType;
 pub use rt::RT;
 pub use ui::{
     Anchor, AttributeType, Code, Color, Column, Common, ConditionalAttribute, ConditionalValue,
-    Container, Element, ExternalFont, FontDisplay, GradientDirection, IFrame, Image, Input, Length,
-    NamedFont, Overflow, Position, Region, Row, Scene, Spacing, Style, Text, TextAlign, TextBlock,
-    TextFormat, Weight,
+    Container, Element, ExternalFont, FontDisplay, GradientDirection, Grid, IFrame, Image, Input,
+    Length, NamedFont, Overflow, Position, Region, Row, Scene, Spacing, Style, Text, TextAlign,
+    TextBlock, TextFormat, Weight,
 };
 pub use variable::{PropertyValue, TextSource, Value, Variable};
 

--- a/src/p2/document.rs
+++ b/src/p2/document.rs
@@ -181,6 +181,15 @@ impl Document {
                             return Some(t);
                         }
                     }
+                    ftd::Element::Grid(c) => {
+                        if let Some(v) = f(e) {
+                            return Some(v);
+                        }
+
+                        if let Some(t) = finder(&c.container.children, f) {
+                            return Some(t);
+                        }
+                    }
                     ftd::Element::Image(_) => {
                         if let Some(v) = f(e) {
                             return Some(v);
@@ -570,7 +579,8 @@ pub fn default_scene_children_position(elements: &mut Vec<ftd::Element>) {
         match element {
             ftd::Element::Scene(ftd::Scene { container, .. })
             | ftd::Element::Row(ftd::Row { container, .. })
-            | ftd::Element::Column(ftd::Column { container, .. }) => {
+            | ftd::Element::Column(ftd::Column { container, .. })
+            | ftd::Element::Grid(ftd::Grid { container, .. }) => {
                 default_scene_children_position(&mut container.children);
                 if let Some((_, _, ref mut ext_children)) = container.external_children {
                     default_scene_children_position(ext_children);

--- a/src/p2/element.rs
+++ b/src/p2/element.rs
@@ -1355,6 +1355,33 @@ pub fn scene_function() -> ftd::Component {
     }
 }
 
+pub fn grid_function() -> ftd::Component {
+    let arguments = {
+        let mut arguments: std::collections::BTreeMap<String, ftd::p2::Kind> =
+            [container_arguments(), common_arguments()]
+                .concat()
+                .into_iter()
+                .collect();
+        arguments.remove("spacing");
+        arguments.remove("wrap");
+        arguments
+    };
+
+    ftd::Component {
+        line_number: 0,
+        kernel: true,
+        root: "ftd.kernel".to_string(),
+        full_name: "ftd#grid".to_string(),
+        arguments,
+        locals: Default::default(),
+        properties: Default::default(),
+        instructions: Default::default(),
+        invocations: Default::default(),
+        condition: None,
+        events: vec![],
+    }
+}
+
 pub fn boolean_function() -> ftd::Component {
     ftd::Component {
         line_number: 0,
@@ -1455,6 +1482,24 @@ pub fn scene_from_properties(
 ) -> ftd::p1::Result<ftd::Scene> {
     let properties = &ftd::p2::utils::properties(properties_with_ref);
     Ok(ftd::Scene {
+        common: common_from_properties(
+            properties, doc, condition, is_child, events, all_locals, root_name, None,
+        )?,
+        container: container_from_properties(properties, doc)?,
+    })
+}
+
+pub fn grid_from_properties(
+    properties_with_ref: &std::collections::BTreeMap<String, (ftd::Value, Option<String>)>,
+    doc: &ftd::p2::TDoc,
+    condition: &Option<ftd::p2::Boolean>,
+    is_child: bool,
+    events: &[ftd::p2::Event],
+    all_locals: &mut ftd::Map,
+    root_name: Option<&str>,
+) -> ftd::p1::Result<ftd::Grid> {
+    let properties = &ftd::p2::utils::properties(properties_with_ref);
+    Ok(ftd::Grid {
         common: common_from_properties(
             properties, doc, condition, is_child, events, all_locals, root_name, None,
         )?,

--- a/src/p2/element.rs
+++ b/src/p2/element.rs
@@ -253,7 +253,7 @@ pub fn common_from_properties(
         )?,
         inner: ftd::p2::utils::bool_with_default("inner", inner_default, properties, doc.name, 0)?,
         z_index: ftd::p2::utils::int_optional("z-index", properties, doc.name, 0)?,
-        grid_area: ftd::p2::utils::string_optional("slot", properties, doc.name, 0)?,
+        slot: ftd::p2::utils::string_optional("slot", properties, doc.name, 0)?,
         grid_column: ftd::p2::utils::string_optional("grid-column", properties, doc.name, 0)?,
         grid_row: ftd::p2::utils::string_optional("grid-row", properties, doc.name, 0)?,
     })

--- a/src/p2/element.rs
+++ b/src/p2/element.rs
@@ -253,7 +253,7 @@ pub fn common_from_properties(
         )?,
         inner: ftd::p2::utils::bool_with_default("inner", inner_default, properties, doc.name, 0)?,
         z_index: ftd::p2::utils::int_optional("z-index", properties, doc.name, 0)?,
-        grid_area: ftd::p2::utils::string_optional("grid-area", properties, doc.name, 0)?,
+        grid_area: ftd::p2::utils::string_optional("slot", properties, doc.name, 0)?,
         grid_column: ftd::p2::utils::string_optional("grid-column", properties, doc.name, 0)?,
         grid_row: ftd::p2::utils::string_optional("grid-row", properties, doc.name, 0)?,
     })
@@ -508,18 +508,15 @@ fn common_arguments() -> Vec<(String, ftd::p2::Kind)> {
             "z-index".to_string(),
             ftd::p2::Kind::integer().into_optional(),
         ),
-        (
-            "grid-area".to_string(),
-            ftd::p2::Kind::string().into_optional(),
-        ),
-        (
+        ("slot".to_string(), ftd::p2::Kind::string().into_optional()),
+        /*(
             "grid-column".to_string(),
             ftd::p2::Kind::string().into_optional(),
         ),
         (
             "grid-row".to_string(),
             ftd::p2::Kind::string().into_optional(),
-        ),
+        ),*/
     ]
 }
 
@@ -540,9 +537,6 @@ pub fn container_from_properties(
         children: Default::default(),
         external_children: Default::default(),
         open: ftd::p2::utils::string_bool_optional("open", properties, doc.name, 0)?,
-        spacing: ftd::Spacing::from(ftd::p2::utils::string_optional(
-            "spacing", properties, doc.name, 0,
-        )?)?,
         wrap: ftd::p2::utils::bool_with_default("wrap", false, properties, doc.name, 0)?,
     })
 }
@@ -550,10 +544,6 @@ pub fn container_from_properties(
 fn container_arguments() -> Vec<(String, ftd::p2::Kind)> {
     vec![
         ("open".to_string(), ftd::p2::Kind::string().into_optional()),
-        (
-            "spacing".to_string(),
-            ftd::p2::Kind::string().into_optional(),
-        ),
         ("align".to_string(), ftd::p2::Kind::string().into_optional()),
         ("wrap".to_string(), ftd::p2::Kind::boolean().into_optional()),
     ]
@@ -617,10 +607,17 @@ pub fn row_function() -> ftd::Component {
         kernel: true,
         full_name: "ftd#row".to_string(),
         root: "ftd.kernel".to_string(),
-        arguments: [container_arguments(), common_arguments()]
-            .concat()
-            .into_iter()
-            .collect(),
+        arguments: [
+            container_arguments(),
+            common_arguments(),
+            vec![(
+                "spacing".to_string(),
+                ftd::p2::Kind::string().into_optional(),
+            )],
+        ]
+        .concat()
+        .into_iter()
+        .collect(),
         locals: Default::default(),
         properties: Default::default(),
         instructions: Default::default(),
@@ -646,6 +643,9 @@ pub fn row_from_properties(
             properties, doc, condition, is_child, events, all_locals, root_name, None,
         )?,
         container: container_from_properties(properties, doc)?,
+        spacing: ftd::Spacing::from(ftd::p2::utils::string_optional(
+            "spacing", properties, doc.name, 0,
+        )?)?,
     })
 }
 
@@ -655,10 +655,17 @@ pub fn column_function() -> ftd::Component {
         kernel: true,
         full_name: "ftd#column".to_string(),
         root: "ftd.kernel".to_string(),
-        arguments: [container_arguments(), common_arguments()]
-            .concat()
-            .into_iter()
-            .collect(),
+        arguments: [
+            container_arguments(),
+            common_arguments(),
+            vec![(
+                "spacing".to_string(),
+                ftd::p2::Kind::string().into_optional(),
+            )],
+        ]
+        .concat()
+        .into_iter()
+        .collect(),
         locals: Default::default(),
         properties: Default::default(),
         instructions: Default::default(),
@@ -683,6 +690,9 @@ pub fn column_from_properties(
             properties, doc, condition, is_child, events, all_locals, root_name, None,
         )?,
         container: container_from_properties(properties, doc)?,
+        spacing: ftd::Spacing::from(ftd::p2::utils::string_optional(
+            "spacing", properties, doc.name, 0,
+        )?)?,
     })
 }
 
@@ -1345,11 +1355,17 @@ pub fn decimal_function() -> ftd::Component {
 
 pub fn scene_function() -> ftd::Component {
     let arguments = {
-        let mut arguments: std::collections::BTreeMap<String, ftd::p2::Kind> =
-            [container_arguments(), common_arguments()]
-                .concat()
-                .into_iter()
-                .collect();
+        let mut arguments: std::collections::BTreeMap<String, ftd::p2::Kind> = [
+            container_arguments(),
+            common_arguments(),
+            vec![(
+                "spacing".to_string(),
+                ftd::p2::Kind::string().into_optional(),
+            )],
+        ]
+        .concat()
+        .into_iter()
+        .collect();
         arguments.remove("spacing");
         arguments.remove("wrap");
         arguments
@@ -1371,43 +1387,32 @@ pub fn scene_function() -> ftd::Component {
 }
 
 pub fn grid_function() -> ftd::Component {
-    let arguments = {
-        let mut arguments: std::collections::BTreeMap<String, ftd::p2::Kind> = [
-            vec![
-                ("areas".to_string(), ftd::p2::Kind::string().into_optional()),
-                (
-                    "columns".to_string(),
-                    ftd::p2::Kind::string().into_optional(),
-                ),
-                ("rows".to_string(), ftd::p2::Kind::string().into_optional()),
-                ("gap".to_string(), ftd::p2::Kind::integer().into_optional()),
-                (
-                    "column-gap".to_string(),
-                    ftd::p2::Kind::integer().into_optional(),
-                ),
-                (
-                    "row-gap".to_string(),
-                    ftd::p2::Kind::integer().into_optional(),
-                ),
-                (
-                    "inline".to_string(),
-                    ftd::p2::Kind::boolean().into_optional(),
-                ),
-                (
-                    "auto-flow".to_string(),
-                    ftd::p2::Kind::string().into_optional(),
-                ),
-            ],
-            container_arguments(),
-            common_arguments(),
-        ]
-        .concat()
-        .into_iter()
-        .collect();
-        arguments.remove("spacing");
-        arguments.remove("wrap");
-        arguments
-    };
+    let arguments: std::collections::BTreeMap<String, ftd::p2::Kind> = [
+        container_arguments(),
+        common_arguments(),
+        vec![
+            ("slots".to_string(), ftd::p2::Kind::string()),
+            (
+                "slot-widths".to_string(),
+                ftd::p2::Kind::string().into_optional(),
+            ),
+            (
+                "slot-heights".to_string(),
+                ftd::p2::Kind::string().into_optional(),
+            ),
+            (
+                "spacing".to_string(),
+                ftd::p2::Kind::integer().into_optional(),
+            ),
+            (
+                "inline".to_string(),
+                ftd::p2::Kind::boolean().into_optional(),
+            ),
+        ],
+    ]
+    .concat()
+    .into_iter()
+    .collect();
 
     ftd::Component {
         line_number: 0,
@@ -1528,6 +1533,9 @@ pub fn scene_from_properties(
             properties, doc, condition, is_child, events, all_locals, root_name, None,
         )?,
         container: container_from_properties(properties, doc)?,
+        spacing: ftd::Spacing::from(ftd::p2::utils::string_optional(
+            "spacing", properties, doc.name, 0,
+        )?)?,
     })
 }
 
@@ -1542,12 +1550,25 @@ pub fn grid_from_properties(
 ) -> ftd::p1::Result<ftd::Grid> {
     let properties = &ftd::p2::utils::properties(properties_with_ref);
     Ok(ftd::Grid {
-        areas: ftd::p2::utils::string_optional("areas", properties, doc.name, 0)?,
-        columns: ftd::p2::utils::string_optional("columns", properties, doc.name, 0)?,
-        rows: ftd::p2::utils::string_optional("rows", properties, doc.name, 0)?,
-        gap: ftd::p2::utils::int_optional("gap", properties, doc.name, 0)?,
-        column_gap: ftd::p2::utils::int_optional("column-gap", properties, doc.name, 0)?,
-        row_gap: ftd::p2::utils::int_optional("row-gap", properties, doc.name, 0)?,
+        slots: match ftd::p2::utils::string_optional("slots", properties, doc.name, 0)? {
+            Some(val) => val,
+            None => return ftd::e2("expected slots", doc.name, 0),
+        },
+        slot_widths: ftd::p2::utils::string_optional("slot-widths", properties, doc.name, 0)?,
+        slot_heights: ftd::p2::utils::string_optional("slot-heights", properties, doc.name, 0)?,
+        spacing: ftd::p2::utils::int_optional("spacing", properties, doc.name, 0)?,
+        spacing_vertical: ftd::p2::utils::int_optional(
+            "spacing-vertical",
+            properties,
+            doc.name,
+            0,
+        )?,
+        spacing_horizontal: ftd::p2::utils::int_optional(
+            "spacing-horizontal",
+            properties,
+            doc.name,
+            0,
+        )?,
         common: common_from_properties(
             properties, doc, condition, is_child, events, all_locals, root_name, None,
         )?,

--- a/src/p2/element.rs
+++ b/src/p2/element.rs
@@ -253,6 +253,9 @@ pub fn common_from_properties(
         )?,
         inner: ftd::p2::utils::bool_with_default("inner", inner_default, properties, doc.name, 0)?,
         z_index: ftd::p2::utils::int_optional("z-index", properties, doc.name, 0)?,
+        grid_area: ftd::p2::utils::string_optional("grid-area", properties, doc.name, 0)?,
+        grid_column: ftd::p2::utils::string_optional("grid-column", properties, doc.name, 0)?,
+        grid_row: ftd::p2::utils::string_optional("grid-row", properties, doc.name, 0)?,
     })
 }
 
@@ -504,6 +507,18 @@ fn common_arguments() -> Vec<(String, ftd::p2::Kind)> {
         (
             "z-index".to_string(),
             ftd::p2::Kind::integer().into_optional(),
+        ),
+        (
+            "grid-area".to_string(),
+            ftd::p2::Kind::string().into_optional(),
+        ),
+        (
+            "grid-column".to_string(),
+            ftd::p2::Kind::string().into_optional(),
+        ),
+        (
+            "grid-row".to_string(),
+            ftd::p2::Kind::string().into_optional(),
         ),
     ]
 }
@@ -1357,11 +1372,38 @@ pub fn scene_function() -> ftd::Component {
 
 pub fn grid_function() -> ftd::Component {
     let arguments = {
-        let mut arguments: std::collections::BTreeMap<String, ftd::p2::Kind> =
-            [container_arguments(), common_arguments()]
-                .concat()
-                .into_iter()
-                .collect();
+        let mut arguments: std::collections::BTreeMap<String, ftd::p2::Kind> = [
+            vec![
+                ("areas".to_string(), ftd::p2::Kind::string().into_optional()),
+                (
+                    "columns".to_string(),
+                    ftd::p2::Kind::string().into_optional(),
+                ),
+                ("rows".to_string(), ftd::p2::Kind::string().into_optional()),
+                ("gap".to_string(), ftd::p2::Kind::integer().into_optional()),
+                (
+                    "column-gap".to_string(),
+                    ftd::p2::Kind::integer().into_optional(),
+                ),
+                (
+                    "row-gap".to_string(),
+                    ftd::p2::Kind::integer().into_optional(),
+                ),
+                (
+                    "inline".to_string(),
+                    ftd::p2::Kind::boolean().into_optional(),
+                ),
+                (
+                    "auto-flow".to_string(),
+                    ftd::p2::Kind::string().into_optional(),
+                ),
+            ],
+            container_arguments(),
+            common_arguments(),
+        ]
+        .concat()
+        .into_iter()
+        .collect();
         arguments.remove("spacing");
         arguments.remove("wrap");
         arguments
@@ -1500,9 +1542,17 @@ pub fn grid_from_properties(
 ) -> ftd::p1::Result<ftd::Grid> {
     let properties = &ftd::p2::utils::properties(properties_with_ref);
     Ok(ftd::Grid {
+        areas: ftd::p2::utils::string_optional("areas", properties, doc.name, 0)?,
+        columns: ftd::p2::utils::string_optional("columns", properties, doc.name, 0)?,
+        rows: ftd::p2::utils::string_optional("rows", properties, doc.name, 0)?,
+        gap: ftd::p2::utils::int_optional("gap", properties, doc.name, 0)?,
+        column_gap: ftd::p2::utils::int_optional("column-gap", properties, doc.name, 0)?,
+        row_gap: ftd::p2::utils::int_optional("row-gap", properties, doc.name, 0)?,
         common: common_from_properties(
             properties, doc, condition, is_child, events, all_locals, root_name, None,
         )?,
         container: container_from_properties(properties, doc)?,
+        inline: ftd::p2::utils::bool_with_default("inline", false, properties, doc.name, 0)?,
+        auto_flow: ftd::p2::utils::string_optional("auto-flow", properties, doc.name, 0)?,
     })
 }

--- a/src/p2/interpreter.rs
+++ b/src/p2/interpreter.rs
@@ -766,6 +766,7 @@ pub fn default_column() -> ftd::Column {
             wrap: true,
             ..Default::default()
         },
+        spacing: None,
     }
 }
 
@@ -1464,10 +1465,13 @@ mod test {
         main.container
             .children
             .push(ftd::Element::Column(ftd::Column {
+                spacing: None,
                 container: ftd::Container {
                     children: vec![ftd::Element::Column(ftd::Column {
+                        spacing: None,
                         container: ftd::Container {
                             children: vec![ftd::Element::Column(ftd::Column {
+                                spacing: None,
                                 container: ftd::Container {
                                     children: vec![
                                         ftd::Element::Text(ftd::Text {
@@ -1488,6 +1492,7 @@ mod test {
                                         }),
                                         ftd::Element::Null,
                                         ftd::Element::Column(ftd::Column {
+                                            spacing: None,
                                             container: ftd::Container {
                                                 children: vec![
                                                     ftd::Element::Null,
@@ -1508,6 +1513,7 @@ mod test {
                                                         ..Default::default()
                                                     }),
                                                     ftd::Element::Column(ftd::Column {
+                                                        spacing: None,
                                                         container: ftd::Container {
                                                             external_children: Default::default(),
                                                             children: vec![
@@ -1568,8 +1574,10 @@ mod test {
                                                 width: Some(ftd::Length::Fill),
                                                 ..Default::default()
                                             },
+                                            ..Default::default()
                                         }),
                                         ftd::Element::Column(ftd::Column {
+                                            spacing: None,
                                             container: ftd::Container {
                                                 external_children: Default::default(),
                                                 children: vec![
@@ -1621,6 +1629,7 @@ mod test {
                                     width: Some(ftd::Length::Fill),
                                     ..Default::default()
                                 },
+                                ..Default::default()
                             })],
                             ..Default::default()
                         },
@@ -1632,6 +1641,7 @@ mod test {
                             width: Some(ftd::Length::Px { value: 300 }),
                             ..Default::default()
                         },
+                        ..Default::default()
                     })],
                     ..Default::default()
                 },
@@ -2176,10 +2186,13 @@ mod test {
         main.container
             .children
             .push(ftd::Element::Column(ftd::Column {
+                spacing: None,
                 container: ftd::Container {
                     children: vec![ftd::Element::Column(ftd::Column {
+                        spacing: None,
                         container: ftd::Container {
                             children: vec![ftd::Element::Column(ftd::Column {
+                                spacing: None,
                                 container: ftd::Container {
                                     children: vec![
                                         ftd::Element::Text(ftd::Text {
@@ -2200,6 +2213,7 @@ mod test {
                                         }),
                                         ftd::Element::Null,
                                         ftd::Element::Column(ftd::Column {
+                                            spacing: None,
                                             container: ftd::Container {
                                                 children: vec![
                                                     ftd::Element::Null,
@@ -2220,6 +2234,7 @@ mod test {
                                                         ..Default::default()
                                                     }),
                                                     ftd::Element::Column(ftd::Column {
+                                                        spacing: None,
                                                         container: ftd::Container {
                                                             external_children: Default::default(),
                                                             children: vec![
@@ -2282,6 +2297,7 @@ mod test {
                                             },
                                         }),
                                         ftd::Element::Column(ftd::Column {
+                                            spacing: None,
                                             container: ftd::Container {
                                                 external_children: Default::default(),
                                                 children: vec![
@@ -2494,6 +2510,7 @@ mod test {
         main.container
             .children
             .push(ftd::Element::Column(ftd::Column {
+                spacing: None,
                 common: ftd::Common {
                     width: Some(ftd::Length::Px { value: 200 }),
                     background_color: Some(ftd::Color {
@@ -3251,7 +3268,7 @@ mod test {
         let mut main = super::default_column();
         main.container
             .children
-            .push(ftd::Element::Column(ftd::Column {
+            .push(ftd::Element::Column(ftd::Column {spacing: None,
                 common: ftd::Common {
                     padding: Some(30),
                     locals: std::array::IntoIter::new([
@@ -3363,7 +3380,7 @@ mod test {
         let mut main = super::default_column();
         main.container
             .children
-            .push(ftd::Element::Column(ftd::Column {
+            .push(ftd::Element::Column(ftd::Column {spacing: None,
                 common: ftd::Common {
                     padding: Some(30),
                     locals: std::array::IntoIter::new([
@@ -3392,6 +3409,7 @@ mod test {
         main.container
             .children
             .push(ftd::Element::Column(ftd::Column {
+                spacing: None,
                 common: ftd::Common {
                     padding: Some(30),
                     locals: std::array::IntoIter::new([
@@ -3514,7 +3532,7 @@ mod test {
         let mut main = super::default_column();
         main.container
             .children
-            .push(ftd::Element::Column(ftd::Column {
+            .push(ftd::Element::Column(ftd::Column {spacing: None,
                 common: ftd::Common {
                     padding: Some(30),
                     locals: std::array::IntoIter::new([
@@ -3543,6 +3561,7 @@ mod test {
         main.container
             .children
             .push(ftd::Element::Column(ftd::Column {
+                spacing: None,
                 common: ftd::Common {
                     padding: Some(30),
                     locals: std::array::IntoIter::new([
@@ -3564,6 +3583,7 @@ mod test {
         main.container
             .children
             .push(ftd::Element::Column(ftd::Column {
+                spacing: None,
                 common: ftd::Common {
                     padding: Some(30),
                     locals: std::array::IntoIter::new([(s("title@2"), s("third call"))]).collect(),
@@ -3726,6 +3746,7 @@ mod test {
         main.container
             .children
             .push(ftd::Element::Column(ftd::Column {
+                spacing: None,
                 container: ftd::Container {
                     children: vec![
                         ftd::Element::Text(ftd::Text {
@@ -3765,6 +3786,7 @@ mod test {
         main.container
             .children
             .push(ftd::Element::Column(ftd::Column {
+                spacing: None,
                 container: ftd::Container {
                     children: vec![
                         ftd::Element::Text(ftd::Text {
@@ -3869,6 +3891,7 @@ mod test {
         main.container
             .children
             .push(ftd::Element::Column(ftd::Column {
+                spacing: None,
                 container: ftd::Container {
                     children: vec![ftd::Element::Image(ftd::Image {
                         src: s("foo.png"),
@@ -3888,6 +3911,7 @@ mod test {
         main.container
             .children
             .push(ftd::Element::Column(ftd::Column {
+                spacing: None,
                 container: ftd::Container {
                     children: vec![ftd::Element::Image(ftd::Image {
                         src: s("bar.png"),
@@ -4653,11 +4677,14 @@ mod test {
         main.container
             .children
             .push(ftd::Element::Column(ftd::Column {
+                spacing: None,
                 container: ftd::Container {
                     children: vec![ftd::Element::Row(ftd::Row {
+                        spacing: None,
                         container: ftd::Container {
                             children: vec![
                                 ftd::Element::Row(ftd::Row {
+                                    spacing: None,
                                     common: ftd::Common {
                                         data_id: Some(s("r2")),
                                         id: Some(s("foo-1:r2")),
@@ -4691,10 +4718,13 @@ mod test {
         main.container
             .children
             .push(ftd::Element::Column(ftd::Column {
+                spacing: None,
                 container: ftd::Container {
                     children: vec![ftd::Element::Row(ftd::Row {
+                        spacing: None,
                         container: ftd::Container {
                             children: vec![ftd::Element::Row(ftd::Row {
+                                spacing: None,
                                 common: ftd::Common {
                                     data_id: Some(s("r2")),
                                     id: Some(s("foo-2:r2")),
@@ -4807,11 +4837,14 @@ mod test {
         main.container
             .children
             .push(ftd::Element::Column(ftd::Column {
+                spacing: None,
                 container: ftd::Container {
                     children: vec![ftd::Element::Row(ftd::Row {
+                        spacing: None,
                         container: ftd::Container {
                             children: vec![
                                 ftd::Element::Row(ftd::Row {
+                                    spacing: None,
                                     common: ftd::Common {
                                         data_id: Some(s("r2")),
                                         id: Some(s("foo-1:r2")),
@@ -4845,10 +4878,13 @@ mod test {
         main.container
             .children
             .push(ftd::Element::Column(ftd::Column {
+                spacing: None,
                 container: ftd::Container {
                     children: vec![ftd::Element::Row(ftd::Row {
+                        spacing: None,
                         container: ftd::Container {
                             children: vec![ftd::Element::Row(ftd::Row {
+                                spacing: None,
                                 common: ftd::Common {
                                     data_id: Some(s("r2")),
                                     id: Some(s("foo-2:r2")),
@@ -4904,6 +4940,7 @@ mod test {
         main.container
             .children
             .push(ftd::Element::Column(ftd::Column {
+                spacing: None,
                 container: ftd::Container {
                     external_children: Some((
                         s("some-child"),
@@ -4911,8 +4948,10 @@ mod test {
                         vec![ftd::Element::Column(external_children)],
                     )),
                     children: vec![ftd::Element::Row(ftd::Row {
+                        spacing: None,
                         container: ftd::Container {
                             children: vec![ftd::Element::Row(ftd::Row {
+                                spacing: None,
                                 common: ftd::Common {
                                     data_id: Some(s("some-child")),
                                     ..Default::default()
@@ -5031,13 +5070,17 @@ mod test {
         main.container
             .children
             .push(ftd::Element::Column(ftd::Column {
+                spacing: None,
                 container: ftd::Container {
                     children: vec![ftd::Element::Column(ftd::Column {
+                        spacing: None,
                         container: ftd::Container {
                             children: vec![ftd::Element::Column(ftd::Column {
+                                spacing: None,
                                 container: ftd::Container {
                                     children: vec![
                                         ftd::Element::Column(ftd::Column {
+                                            spacing: None,
                                             container: ftd::Container {
                                                 children: vec![ftd::Element::Text(ftd::Text {
                                                     text: ftd::markdown_line("Mobile Display"),
@@ -5069,6 +5112,7 @@ mod test {
                                             },
                                         }),
                                         ftd::Element::Column(ftd::Column {
+                                            spacing: None,
                                             container: ftd::Container {
                                                 children: vec![ftd::Element::Text(ftd::Text {
                                                     text: ftd::markdown_line("Desktop Display"),
@@ -5411,13 +5455,17 @@ mod test {
         main.container
             .children
             .push(ftd::Element::Column(ftd::Column {
+                spacing: None,
                 container: ftd::Container {
                     children: vec![ftd::Element::Column(ftd::Column {
+                        spacing: None,
                         container: ftd::Container {
                             children: vec![
                                 ftd::Element::Column(ftd::Column {
+                                    spacing: None,
                                     container: ftd::Container {
                                         children: vec![ftd::Element::Column(ftd::Column {
+                                            spacing: None,
                                             container: ftd::Container {
                                                 children: vec![],
                                                 ..Default::default()
@@ -5446,8 +5494,10 @@ mod test {
                                     },
                                 }),
                                 ftd::Element::Column(ftd::Column {
+                                    spacing: None,
                                     container: ftd::Container {
                                         children: vec![ftd::Element::Column(ftd::Column {
+                                            spacing: None,
                                             common: ftd::Common {
                                                 data_id: Some(s("mobile-container")),
                                                 ..Default::default()
@@ -5559,11 +5609,14 @@ mod test {
         main.container
             .children
             .push(ftd::Element::Column(ftd::Column {
+                spacing: None,
                 container: ftd::Container {
                     children: vec![
                         ftd::Element::Column(ftd::Column {
+                            spacing: None,
                             container: ftd::Container {
                                 children: vec![ftd::Element::Column(ftd::Column {
+                                    spacing: None,
                                     common: ftd::Common {
                                         data_id: Some(s("foo")),
                                         ..Default::default()
@@ -5588,8 +5641,10 @@ mod test {
                             },
                         }),
                         ftd::Element::Column(ftd::Column {
+                            spacing: None,
                             container: ftd::Container {
                                 children: vec![ftd::Element::Column(ftd::Column {
+                                    spacing: None,
                                     common: ftd::Common {
                                         data_id: Some(s("foo")),
                                         ..Default::default()
@@ -5687,10 +5742,13 @@ mod test {
 
         let mut external_children = super::default_column();
         external_children.container.children = vec![ftd::Element::Column(ftd::Column {
+            spacing: None,
             container: ftd::Container {
                 children: vec![ftd::Element::Row(ftd::Row {
+                    spacing: None,
                     container: ftd::Container {
                         children: vec![ftd::Element::Column(ftd::Column {
+                            spacing: None,
                             common: ftd::Common {
                                 locals: std::array::IntoIter::new([(s("id@0,0,0,0"), s("foo"))])
                                     .collect(),
@@ -5721,13 +5779,17 @@ mod test {
         main.container
             .children
             .push(ftd::Element::Column(ftd::Column {
+                spacing: None,
                 container: ftd::Container {
                     children: vec![
                         ftd::Element::Column(ftd::Column {
+                            spacing: None,
                             container: ftd::Container {
                                 children: vec![ftd::Element::Row(ftd::Row {
+                                    spacing: None,
                                     container: ftd::Container {
                                         children: vec![ftd::Element::Column(ftd::Column {
+                                            spacing: None,
                                             common: ftd::Common {
                                                 locals: std::array::IntoIter::new([(
                                                     s("id@0,0,0,0"),
@@ -5770,10 +5832,13 @@ mod test {
                             ..Default::default()
                         }),
                         ftd::Element::Column(ftd::Column {
+                            spacing: None,
                             container: ftd::Container {
                                 children: vec![ftd::Element::Row(ftd::Row {
+                                    spacing: None,
                                     container: ftd::Container {
                                         children: vec![ftd::Element::Column(ftd::Column {
+                                            spacing: None,
                                             common: ftd::Common {
                                                 locals: std::array::IntoIter::new([(
                                                     s("id@0,1,0,0"),
@@ -5920,13 +5985,17 @@ mod test {
         main.container
             .children
             .push(ftd::Element::Column(ftd::Column {
+                spacing: None,
                 container: ftd::Container {
                     children: vec![ftd::Element::Column(ftd::Column {
+                        spacing: None,
                         container: ftd::Container {
                             children: vec![
                                 ftd::Element::Column(ftd::Column {
+                                    spacing: None,
                                     container: ftd::Container {
                                         children: vec![ftd::Element::Column(ftd::Column {
+                                            spacing: None,
                                             container: ftd::Container {
                                                 children: vec![],
                                                 ..Default::default()
@@ -5948,8 +6017,10 @@ mod test {
                                     },
                                 }),
                                 ftd::Element::Column(ftd::Column {
+                                    spacing: None,
                                     container: ftd::Container {
                                         children: vec![ftd::Element::Column(ftd::Column {
+                                            spacing: None,
                                             common: ftd::Common {
                                                 data_id: Some(s("main-container")),
                                                 ..Default::default()
@@ -6037,6 +6108,7 @@ mod test {
     fn open_container_id_1() {
         let mut main = self::default_column();
         main.container.children.push(ftd::Element::Row(ftd::Row {
+            spacing: None,
             common: ftd::Common {
                 data_id: Some(s("r1")),
                 id: Some(s("r1")),
@@ -6048,6 +6120,7 @@ mod test {
             },
         }));
         main.container.children.push(ftd::Element::Row(ftd::Row {
+            spacing: None,
             container: ftd::Container {
                 external_children: Default::default(),
                 children: vec![
@@ -6057,6 +6130,7 @@ mod test {
                         ..Default::default()
                     }),
                     ftd::Element::Row(ftd::Row {
+                        spacing: None,
                         container: ftd::Container {
                             open: (Some(false), None),
                             ..Default::default()
@@ -6136,6 +6210,7 @@ mod test {
     fn basic_loop_on_record_1() {
         let mut main = super::default_column();
         main.container.children.push(ftd::Element::Row(ftd::Row {
+            spacing: None,
             container: ftd::Container {
                 children: vec![
                     ftd::Element::Text(ftd::Text {
@@ -6170,6 +6245,7 @@ mod test {
         }));
 
         main.container.children.push(ftd::Element::Row(ftd::Row {
+            spacing: None,
             container: ftd::Container {
                 children: vec![
                     ftd::Element::Text(ftd::Text {
@@ -6203,6 +6279,7 @@ mod test {
         }));
 
         main.container.children.push(ftd::Element::Row(ftd::Row {
+            spacing: None,
             container: ftd::Container {
                 children: vec![
                     ftd::Element::Text(ftd::Text {
@@ -6440,6 +6517,7 @@ mod test {
         main.container.children.push(ftd::Element::Null);
 
         main.container.children.push(ftd::Element::Row(ftd::Row {
+            spacing: None,
             container: ftd::Container {
                 children: vec![
                     ftd::Element::Text(ftd::Text {
@@ -6738,6 +6816,7 @@ mod test {
         };
 
         col.container.children.push(ftd::Element::Row(ftd::Row {
+            spacing: None,
             container: ftd::Container {
                 children: vec![
                     ftd::Element::Text(ftd::Text {
@@ -6771,6 +6850,7 @@ mod test {
         }));
 
         col.container.children.push(ftd::Element::Row(ftd::Row {
+            spacing: None,
             container: ftd::Container {
                 children: vec![
                     ftd::Element::Text(ftd::Text {
@@ -7234,6 +7314,7 @@ mod test {
         let mut main = super::default_column();
 
         main.container.children.push(ftd::Element::Row(ftd::Row {
+            spacing: None,
             container: ftd::Container {
                 children: vec![
                     ftd::Element::Text(ftd::Text {
@@ -7268,6 +7349,7 @@ mod test {
         }));
 
         main.container.children.push(ftd::Element::Row(ftd::Row {
+            spacing: None,
             container: ftd::Container {
                 children: vec![
                     ftd::Element::Text(ftd::Text {
@@ -7302,6 +7384,7 @@ mod test {
         }));
 
         main.container.children.push(ftd::Element::Row(ftd::Row {
+            spacing: None,
             container: ftd::Container {
                 children: vec![
                     ftd::Element::Text(ftd::Text {
@@ -7336,6 +7419,7 @@ mod test {
         }));
 
         main.container.children.push(ftd::Element::Row(ftd::Row {
+            spacing: None,
             container: ftd::Container {
                 children: vec![
                     ftd::Element::Text(ftd::Text {
@@ -7370,6 +7454,7 @@ mod test {
         }));
 
         main.container.children.push(ftd::Element::Row(ftd::Row {
+            spacing: None,
             container: ftd::Container {
                 children: vec![
                     ftd::Element::Text(ftd::Text {
@@ -7404,6 +7489,7 @@ mod test {
         }));
 
         main.container.children.push(ftd::Element::Row(ftd::Row {
+            spacing: None,
             container: ftd::Container {
                 children: vec![
                     ftd::Element::Text(ftd::Text {
@@ -7438,6 +7524,7 @@ mod test {
         }));
 
         main.container.children.push(ftd::Element::Row(ftd::Row {
+            spacing: None,
             container: ftd::Container {
                 children: vec![
                     ftd::Element::Text(ftd::Text {
@@ -7472,6 +7559,7 @@ mod test {
         }));
 
         main.container.children.push(ftd::Element::Row(ftd::Row {
+            spacing: None,
             container: ftd::Container {
                 children: vec![
                     ftd::Element::Text(ftd::Text {
@@ -7816,6 +7904,7 @@ mod test {
     fn loop_with_tree_structure() {
         let mut main = super::default_column();
         let col = ftd::Element::Column(ftd::Column {
+            spacing: None,
             container: ftd::Container {
                 children: vec![
                     ftd::Element::Text(ftd::Text {
@@ -7829,6 +7918,7 @@ mod test {
                         ..Default::default()
                     }),
                     ftd::Element::Column(ftd::Column {
+                        spacing: None,
                         container: ftd::Container {
                             children: vec![ftd::Element::Text(ftd::Text {
                                 text: ftd::markdown_line("aa title"),
@@ -7845,6 +7935,7 @@ mod test {
                         ..Default::default()
                     }),
                     ftd::Element::Column(ftd::Column {
+                        spacing: None,
                         container: ftd::Container {
                             children: vec![ftd::Element::Text(ftd::Text {
                                 text: ftd::markdown_line("aaa title"),
@@ -7867,6 +7958,7 @@ mod test {
         });
         main.container.children.push(col.clone());
         main.container.children.push(ftd::Element::Row(ftd::Row {
+            spacing: None,
             container: ftd::Container {
                 children: vec![col],
                 ..Default::default()
@@ -8244,6 +8336,7 @@ mod test {
     fn import_check() {
         let mut main = super::default_column();
         main.container.children.push(ftd::Element::Row(ftd::Row {
+            spacing: None,
             container: ftd::Container {
                 children: vec![ftd::Element::Text(ftd::Text {
                     text: ftd::markdown_line("Hello World"),
@@ -8631,6 +8724,7 @@ mod test {
     fn default_with_reference() {
         let mut main = super::default_column();
         main.container.children.push(ftd::Element::Row(ftd::Row {
+            spacing: None,
             container: ftd::Container {
                 children: vec![ftd::Element::Text(ftd::Text {
                     text: ftd::markdown_line("Arpita"),
@@ -8654,6 +8748,7 @@ mod test {
             },
         }));
         main.container.children.push(ftd::Element::Row(ftd::Row {
+            spacing: None,
             container: ftd::Container {
                 children: vec![ftd::Element::Text(ftd::Text {
                     text: ftd::markdown_line("Amit Upadhayay"),
@@ -8991,12 +9086,16 @@ mod test {
         main.container
             .children
             .push(ftd::Element::Column(ftd::Column {
+                spacing: None,
                 container: ftd::Container {
                     children: vec![ftd::Element::Column(ftd::Column {
+                        spacing: None,
                         container: ftd::Container {
                             children: vec![ftd::Element::Row(ftd::Row {
+                                spacing: None,
                                 container: ftd::Container {
                                     children: vec![ftd::Element::Column(ftd::Column {
+                                        spacing: None,
                                         container: ftd::Container {
                                             children: vec![ftd::Element::Text(ftd::Text {
                                                 text: ftd::markdown_line("hello"),
@@ -9029,13 +9128,17 @@ mod test {
         main.container
             .children
             .push(ftd::Element::Column(ftd::Column {
+                spacing: None,
                 container: ftd::Container {
                     children: vec![
                         ftd::Element::Column(ftd::Column {
+                            spacing: None,
                             container: ftd::Container {
                                 children: vec![ftd::Element::Row(ftd::Row {
+                                    spacing: None,
                                     container: ftd::Container {
                                         children: vec![ftd::Element::Column(ftd::Column {
+                                            spacing: None,
                                             container: ftd::Container {
                                                 children: vec![ftd::Element::Text(ftd::Text {
                                                     text: ftd::markdown_line("hello"),
@@ -9065,6 +9168,7 @@ mod test {
                             },
                         }),
                         ftd::Element::Row(ftd::Row {
+                            spacing: None,
                             common: ftd::Common {
                                 data_id: Some(s("page-id-row")),
                                 id: Some(s("page-id-row")),
@@ -9083,6 +9187,7 @@ mod test {
             }));
 
         main.container.children.push(ftd::Element::Row(ftd::Row {
+            spacing: None,
             ..Default::default()
         }));
 
@@ -9136,6 +9241,7 @@ mod test {
         main.container
             .children
             .push(ftd::Element::Column(ftd::Column {
+                spacing: None,
                 container: ftd::Container {
                     children: vec![ftd::Element::Text(ftd::Text {
                         text: ftd::markdown_line("Heading 31"),
@@ -9160,6 +9266,7 @@ mod test {
         main.container
             .children
             .push(ftd::Element::Column(ftd::Column {
+                spacing: None,
                 container: ftd::Container {
                     children: vec![
                         ftd::Element::Text(ftd::Text {
@@ -9173,6 +9280,7 @@ mod test {
                             ..Default::default()
                         }),
                         ftd::Element::Column(ftd::Column {
+                            spacing: None,
                             container: ftd::Container {
                                 children: vec![
                                     ftd::Element::Text(ftd::Text {
@@ -9186,6 +9294,7 @@ mod test {
                                         ..Default::default()
                                     }),
                                     ftd::Element::Column(ftd::Column {
+                                        spacing: None,
                                         container: ftd::Container {
                                             children: vec![
                                                 ftd::Element::Text(ftd::Text {
@@ -9232,6 +9341,7 @@ mod test {
                             },
                         }),
                         ftd::Element::Column(ftd::Column {
+                            spacing: None,
                             container: ftd::Container {
                                 children: vec![ftd::Element::Text(ftd::Text {
                                     text: ftd::markdown_line("Heading 22"),
@@ -9257,6 +9367,7 @@ mod test {
                             },
                         }),
                         ftd::Element::Column(ftd::Column {
+                            spacing: None,
                             container: ftd::Container {
                                 children: vec![ftd::Element::Text(ftd::Text {
                                     text: ftd::markdown_line("Heading 23"),
@@ -9295,6 +9406,7 @@ mod test {
         main.container
             .children
             .push(ftd::Element::Column(ftd::Column {
+                spacing: None,
                 container: ftd::Container {
                     children: vec![
                         ftd::Element::Text(ftd::Text {
@@ -9308,6 +9420,7 @@ mod test {
                             ..Default::default()
                         }),
                         ftd::Element::Column(ftd::Column {
+                            spacing: None,
                             container: ftd::Container {
                                 children: vec![ftd::Element::Text(ftd::Text {
                                     text: ftd::markdown_line("Heading 33"),
@@ -9333,6 +9446,7 @@ mod test {
                             },
                         }),
                         ftd::Element::Column(ftd::Column {
+                            spacing: None,
                             container: ftd::Container {
                                 children: vec![ftd::Element::Text(ftd::Text {
                                     text: ftd::markdown_line("Heading 24"),
@@ -9434,6 +9548,7 @@ mod test {
         main.container
             .children
             .push(ftd::Element::Column(ftd::Column {
+                spacing: None,
                 container: ftd::Container {
                     children: vec![
                         ftd::Element::Text(ftd::Text {
@@ -9633,6 +9748,7 @@ mod test {
         main.container
             .children
             .push(ftd::Element::Column(ftd::Column {
+                spacing: None,
                 container: ftd::Container {
                     children: vec![
                         ftd::Element::Text(ftd::Text {
@@ -9717,6 +9833,7 @@ mod test {
         main.container
             .children
             .push(ftd::Element::Column(ftd::Column {
+                spacing: None,
                 container: ftd::Container {
                     children: vec![
                         ftd::Element::Text(ftd::Text {
@@ -9737,6 +9854,7 @@ mod test {
                             ..Default::default()
                         }),
                         ftd::Element::Column(ftd::Column {
+                            spacing: None,
                             container: ftd::Container {
                                 children: vec![ftd::Element::Text(ftd::Text {
                                     text: ftd::markdown_line("aa title"),
@@ -9768,6 +9886,7 @@ mod test {
                             },
                         }),
                         ftd::Element::Column(ftd::Column {
+                            spacing: None,
                             container: ftd::Container {
                                 children: vec![ftd::Element::Text(ftd::Text {
                                     text: ftd::markdown_line("aaa title"),
@@ -9859,11 +9978,14 @@ mod test {
         main.container
             .children
             .push(ftd::Element::Column(ftd::Column {
+                spacing: None,
                 container: ftd::Container {
                     children: vec![ftd::Element::Column(ftd::Column {
+                        spacing: None,
                         container: ftd::Container {
                             children: vec![
                                 ftd::Element::Column(ftd::Column {
+                                    spacing: None,
                                     container: ftd::Container {
                                         children: vec![
                                             ftd::Element::Text(ftd::Text {
@@ -9893,6 +10015,7 @@ mod test {
                                     ..Default::default()
                                 }),
                                 ftd::Element::Column(ftd::Column {
+                                    spacing: None,
                                     container: ftd::Container {
                                         children: vec![ftd::Element::Text(ftd::Text {
                                             text: ftd::markdown_line("Hello Bar"),
@@ -10098,6 +10221,7 @@ mod test {
         }));
 
         main.container.children.push(ftd::Element::Row(ftd::Row {
+            spacing: None,
             container: ftd::Container {
                 children: vec![ftd::Element::Text(ftd::Text {
                     text: ftd::markdown_line("hello5"),
@@ -10119,6 +10243,7 @@ mod test {
         }));
 
         main.container.children.push(ftd::Element::Row(ftd::Row {
+            spacing: None,
             container: ftd::Container {
                 children: vec![ftd::Element::Text(ftd::Text {
                     text: ftd::markdown("/foo says hello"),
@@ -10183,9 +10308,11 @@ mod test {
         main.container
             .children
             .push(ftd::Element::Column(ftd::Column {
+                spacing: None,
                 container: ftd::Container {
                     children: vec![
                         ftd::Element::Column(ftd::Column {
+                            spacing: None,
                             container: ftd::Container {
                                 children: vec![
                                     ftd::Element::Text(ftd::Text {
@@ -10431,6 +10558,7 @@ mod test {
         main.container
             .children
             .push(ftd::Element::Column(ftd::Column {
+                spacing: None,
                 container: ftd::Container {
                     children: vec![
                         ftd::Element::Integer(ftd::Text {
@@ -10528,6 +10656,7 @@ mod test {
     fn nested_component() {
         let mut main = super::default_column();
         main.container.children.push(ftd::Element::Row(ftd::Row {
+            spacing: None,
             common: ftd::Common {
                 locals: std::array::IntoIter::new([(s("cta@0"), s("CTA says Hello"))]).collect(),
                 ..Default::default()
@@ -10666,6 +10795,7 @@ mod test {
         main.container
             .children
             .push(ftd::Element::Column(ftd::Column {
+                spacing: None,
                 container: ftd::Container {
                     children: vec![
                         ftd::Element::Text(ftd::Text {
@@ -10722,9 +10852,11 @@ mod test {
     fn open_container_with_parent_id() {
         let mut main = super::default_column();
         let beverage_external_children = vec![ftd::Element::Column(ftd::Column {
+            spacing: None,
             container: ftd::Container {
                 children: vec![
                     ftd::Element::Column(ftd::Column {
+                        spacing: None,
                         container: ftd::Container {
                             children: vec![
                                 ftd::Element::Text(ftd::Text {
@@ -10745,6 +10877,7 @@ mod test {
                                     ..Default::default()
                                 }),
                                 ftd::Element::Column(ftd::Column {
+                                    spacing: None,
                                     common: ftd::Common {
                                         condition: Some(ftd::Condition {
                                             variable: s("@visible@0,0,0"),
@@ -10770,6 +10903,7 @@ mod test {
                         },
                     }),
                     ftd::Element::Column(ftd::Column {
+                        spacing: None,
                         container: ftd::Container {
                             children: vec![
                                 ftd::Element::Text(ftd::Text {
@@ -10790,6 +10924,7 @@ mod test {
                                     ..Default::default()
                                 }),
                                 ftd::Element::Column(ftd::Column {
+                                    spacing: None,
                                     common: ftd::Common {
                                         condition: Some(ftd::Condition {
                                             variable: s("@visible@0,0,1"),
@@ -10805,8 +10940,10 @@ mod test {
                                 s("some-child"),
                                 vec![vec![1]],
                                 vec![ftd::Element::Column(ftd::Column {
+                                    spacing: None,
                                     container: ftd::Container {
                                         children: vec![ftd::Element::Column(ftd::Column {
+                                            spacing: None,
                                             container: ftd::Container {
                                                 children: vec![
                                                     ftd::Element::Text(ftd::Text {
@@ -10827,6 +10964,7 @@ mod test {
                                                         ..Default::default()
                                                     }),
                                                     ftd::Element::Column(ftd::Column {
+                                                        spacing: None,
                                                         common: ftd::Common {
                                                             condition: Some(ftd::Condition {
                                                                 variable: s("@visible@0,0,1,0"),
@@ -10893,8 +11031,10 @@ mod test {
         main.container
             .children
             .push(ftd::Element::Column(ftd::Column {
+                spacing: None,
                 container: ftd::Container {
                     children: vec![ftd::Element::Column(ftd::Column {
+                        spacing: None,
                         container: ftd::Container {
                             children: vec![
                                 ftd::Element::Text(ftd::Text {
@@ -10915,6 +11055,7 @@ mod test {
                                     ..Default::default()
                                 }),
                                 ftd::Element::Column(ftd::Column {
+                                    spacing: None,
                                     common: ftd::Common {
                                         condition: Some(ftd::Condition {
                                             variable: s("@visible@0,0"),
@@ -11002,6 +11143,7 @@ mod test {
         main.container
             .children
             .push(ftd::Element::Column(ftd::Column {
+                spacing: None,
                 container: ftd::Container {
                     children: vec![
                         ftd::Element::Text(ftd::Text {
@@ -11118,6 +11260,7 @@ mod test {
         main.container
             .children
             .push(ftd::Element::Column(ftd::Column {
+                spacing: None,
                 container: ftd::Container {
                     children: vec![
                         ftd::Element::Text(ftd::Text {
@@ -11164,6 +11307,7 @@ mod test {
         main.container
             .children
             .push(ftd::Element::Column(ftd::Column {
+                spacing: None,
                 container: ftd::Container {
                     children: vec![
                         ftd::Element::Text(ftd::Text {
@@ -11250,6 +11394,7 @@ mod test {
         main.container
             .children
             .push(ftd::Element::Column(ftd::Column {
+                spacing: None,
                 container: ftd::Container {
                     children: vec![ftd::Element::Text(ftd::Text {
                         text: ftd::markdown_line("hello"),
@@ -11268,6 +11413,7 @@ mod test {
         main.container
             .children
             .push(ftd::Element::Column(ftd::Column {
+                spacing: None,
                 container: ftd::Container {
                     children: vec![ftd::Element::Text(ftd::Text {
                         text: ftd::markdown_line("hello"),
@@ -11324,6 +11470,7 @@ mod test {
         main.container
             .children
             .push(ftd::Element::Column(ftd::Column {
+                spacing: None,
                 container: ftd::Container {
                     children: vec![
                         ftd::Element::Null,
@@ -11341,6 +11488,7 @@ mod test {
         main.container
             .children
             .push(ftd::Element::Column(ftd::Column {
+                spacing: None,
                 container: ftd::Container {
                     children: vec![
                         ftd::Element::Text(ftd::Text {
@@ -11403,6 +11551,7 @@ mod test {
         main.container
             .children
             .push(ftd::Element::Column(ftd::Column {
+                spacing: None,
                 container: ftd::Container {
                     children: vec![ftd::Element::Text(ftd::Text {
                         text: ftd::markdown_line("Hello"),
@@ -11467,8 +11616,10 @@ mod test {
         main.container
             .children
             .push(ftd::Element::Column(ftd::Column {
+                spacing: None,
                 container: ftd::Container {
                     children: vec![ftd::Element::Column(ftd::Column {
+                        spacing: None,
                         common: ftd::Common {
                             id: Some(s("foo-id:some-id")),
                             data_id: Some(s("some-id")),
@@ -11531,9 +11682,11 @@ mod test {
         main.container
             .children
             .push(ftd::Element::Column(ftd::Column {
+                spacing: None,
                 container: ftd::Container {
                     children: vec![
                         ftd::Element::Column(ftd::Column {
+                            spacing: None,
                             container: ftd::Container {
                                 children: vec![ftd::Element::Text(ftd::Text {
                                     text: ftd::markdown_line("commit message 1"),
@@ -11549,6 +11702,7 @@ mod test {
                             ..Default::default()
                         }),
                         ftd::Element::Column(ftd::Column {
+                            spacing: None,
                             container: ftd::Container {
                                 children: vec![ftd::Element::Text(ftd::Text {
                                     text: ftd::markdown_line("commit message 2"),
@@ -11564,6 +11718,7 @@ mod test {
                             ..Default::default()
                         }),
                         ftd::Element::Column(ftd::Column {
+                            spacing: None,
                             container: ftd::Container {
                                 children: vec![ftd::Element::Text(ftd::Text {
                                     text: ftd::markdown_line("file filename 1"),
@@ -11579,6 +11734,7 @@ mod test {
                             ..Default::default()
                         }),
                         ftd::Element::Column(ftd::Column {
+                            spacing: None,
                             container: ftd::Container {
                                 children: vec![ftd::Element::Text(ftd::Text {
                                     text: ftd::markdown_line("file filename 2"),
@@ -11676,6 +11832,7 @@ mod test {
         main.container
             .children
             .push(ftd::Element::Scene(ftd::Scene {
+                spacing: None,
                 container: ftd::Container {
                     children: vec![ftd::Element::Text(ftd::Text {
                         text: ftd::markdown_line("Hello"),
@@ -11914,8 +12071,10 @@ mod test {
     fn inner_container_check() {
         let mut main = super::default_column();
         let col = ftd::Element::Column(ftd::Column {
+            spacing: None,
             container: ftd::Container {
                 children: vec![ftd::Element::Column(ftd::Column {
+                    spacing: None,
                     container: ftd::Container {
                         children: vec![
                             ftd::Element::Image(ftd::Image {
@@ -12051,6 +12210,7 @@ mod test {
         main.container
             .children
             .push(ftd::Element::Column(ftd::Column {
+                spacing: None,
                 container: ftd::Container {
                     children: vec![
                         ftd::Element::Text(ftd::Text {
@@ -12066,6 +12226,7 @@ mod test {
                             ..Default::default()
                         }),
                         ftd::Element::Column(ftd::Column {
+                            spacing: None,
                             container: ftd::Container {
                                 children: vec![ftd::Element::Text(ftd::Text {
                                     text: ftd::markdown_line("Hello Again"),
@@ -12158,6 +12319,7 @@ mod test {
     fn new_syntax() {
         let mut main = super::default_column();
         main.container.children.push(ftd::Element::Row(ftd::Row {
+            spacing: None,
             container: ftd::Container {
                 children: vec![ftd::Element::Integer(ftd::Text {
                     text: ftd::markdown_line("20"),
@@ -12254,8 +12416,10 @@ mod test {
     fn condition_check() {
         let mut main = super::default_column();
         main.container.children.push(ftd::Element::Row(ftd::Row {
+            spacing: None,
             container: ftd::Container {
                 children: vec![ftd::Element::Column(ftd::Column {
+                    spacing: None,
                     container: ftd::Container {
                         children: vec![ftd::Element::Text(ftd::Text {
                             text: ftd::markdown_line("Hello"),
@@ -12328,6 +12492,7 @@ mod test {
         main.container
             .children
             .push(ftd::Element::Column(ftd::Column {
+                spacing: None,
                 container: ftd::Container {
                     children: vec![
                         ftd::Element::Integer(ftd::Text {
@@ -12410,6 +12575,7 @@ mod test {
             }));
 
         main.container.children.push(ftd::Element::Row(ftd::Row {
+            spacing: None,
             container: ftd::Container {
                 children: vec![ftd::Element::Text(ftd::Text {
                     text: ftd::markdown_line("hello"),
@@ -12533,6 +12699,7 @@ mod test {
         main.container
             .children
             .push(ftd::Element::Column(ftd::Column {
+                spacing: None,
                 container: ftd::Container {
                     children: vec![
                         ftd::Element::Text(ftd::Text {
@@ -12656,6 +12823,7 @@ mod test {
         main.container
             .children
             .push(ftd::Element::Column(ftd::Column {
+                spacing: None,
                 container: ftd::Container {
                     children: vec![
                         ftd::Element::Text(ftd::Text {
@@ -12681,6 +12849,7 @@ mod test {
                             ..Default::default()
                         }),
                         ftd::Element::Column(ftd::Column {
+                            spacing: None,
                             container: ftd::Container {
                                 children: vec![
                                     ftd::Element::Text(ftd::Text {

--- a/src/p2/interpreter.rs
+++ b/src/p2/interpreter.rs
@@ -735,6 +735,10 @@ pub fn default_bag() -> std::collections::BTreeMap<String, ftd::p2::Thing> {
             ftd::p2::Thing::Component(ftd::p2::element::scene_function()),
         ),
         (
+            "ftd#grid".to_string(),
+            ftd::p2::Thing::Component(ftd::p2::element::grid_function()),
+        ),
+        (
             "ftd#input".to_string(),
             ftd::p2::Thing::Component(ftd::p2::element::input_function()),
         ),

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -13,6 +13,7 @@ pub enum Element {
     Boolean(Text),
     Decimal(Text),
     Scene(Scene),
+    Grid(Grid),
     Null,
 }
 
@@ -54,6 +55,11 @@ impl Element {
                     container,
                 })
                 | Self::Scene(ftd::Scene {
+                    common: ftd::Common { data_id: id, .. },
+                    container,
+                    ..
+                })
+                | Self::Grid(ftd::Grid {
                     common: ftd::Common { data_id: id, .. },
                     container,
                     ..
@@ -161,6 +167,16 @@ impl Element {
                         ..
                     },
                 ..
+            })
+            | Self::Grid(ftd::Grid {
+                common: ftd::Common { data_id: id, .. },
+                container:
+                    ftd::Container {
+                        external_children,
+                        children,
+                        ..
+                    },
+                ..
             }) => (
                 id,
                 external_children
@@ -256,6 +272,7 @@ impl Element {
                 ftd::Element::Row(ftd::Row { container, .. }) => container,
                 ftd::Element::Column(ftd::Column { container, .. }) => container,
                 ftd::Element::Scene(ftd::Scene { container, .. }) => container,
+                ftd::Element::Grid(ftd::Grid { container, .. }) => container,
                 _ => continue,
             };
             let all_locals = ftd::Element::get_external_children_dependencies(&container.children);
@@ -311,6 +328,15 @@ impl Element {
                     container,
                 })
                 | ftd::Element::Scene(ftd::Scene {
+                    common:
+                        ftd::Common {
+                            conditional_attribute,
+                            data_id: id,
+                            ..
+                        },
+                    container,
+                })
+                | ftd::Element::Grid(ftd::Grid {
                     common:
                         ftd::Common {
                             conditional_attribute,
@@ -413,6 +439,15 @@ impl Element {
                             ..
                         },
                     container,
+                })
+                | ftd::Element::Grid(ftd::Grid {
+                    common:
+                        ftd::Common {
+                            reference,
+                            data_id: id,
+                            ..
+                        },
+                    container,
                 }) => {
                     ftd::Element::get_value_event_dependencies(&container.children, data);
                     if let Some((_, _, external_children)) = &container.external_children {
@@ -487,6 +522,15 @@ impl Element {
                             ..
                         },
                     container,
+                })
+                | ftd::Element::Grid(ftd::Grid {
+                    common:
+                        ftd::Common {
+                            condition,
+                            data_id: id,
+                            ..
+                        },
+                    container,
                 }) => {
                     ftd::Element::get_visible_event_dependencies(&container.children, data);
                     if let Some((_, _, external_children)) = &container.external_children {
@@ -546,6 +590,10 @@ impl Element {
                 | ftd::Element::Scene(ftd::Scene {
                     common: ftd::Common { locals, .. },
                     container,
+                })
+                | ftd::Element::Grid(ftd::Grid {
+                    common: ftd::Common { locals, .. },
+                    container,
                 }) => {
                     let mut all_locals = ftd::Element::get_locals(&container.children);
                     for (k, v) in locals {
@@ -582,6 +630,7 @@ impl Element {
             ftd::Element::Column(e) => e.container.is_open(is_container_children_empty),
             ftd::Element::Row(e) => e.container.is_open(is_container_children_empty),
             ftd::Element::Scene(e) => e.container.is_open(is_container_children_empty),
+            ftd::Element::Grid(e) => e.container.is_open(is_container_children_empty),
             _ => (false, None),
         }
     }
@@ -591,6 +640,7 @@ impl Element {
             ftd::Element::Column(e) => e.common.data_id.clone(),
             ftd::Element::Row(e) => e.common.data_id.clone(),
             ftd::Element::Scene(e) => e.common.data_id.clone(),
+            ftd::Element::Grid(e) => e.common.data_id.clone(),
             _ => None,
         }
     }
@@ -600,6 +650,7 @@ impl Element {
             ftd::Element::Column(e) => e.common.data_id = name,
             ftd::Element::Row(e) => e.common.data_id = name,
             ftd::Element::Scene(e) => e.common.data_id = name,
+            ftd::Element::Grid(e) => e.common.data_id = name,
             _ => {}
         }
     }
@@ -617,7 +668,8 @@ impl Element {
             | ftd::Element::Integer(ftd::Text { common, .. })
             | ftd::Element::Boolean(ftd::Text { common, .. })
             | ftd::Element::Decimal(ftd::Text { common, .. })
-            | ftd::Element::Scene(ftd::Scene { common, .. }) => common.id = name,
+            | ftd::Element::Scene(ftd::Scene { common, .. })
+            | ftd::Element::Grid(ftd::Grid { common, .. }) => common.id = name,
             ftd::Element::Null => {}
         }
     }
@@ -635,7 +687,8 @@ impl Element {
             | ftd::Element::Integer(ftd::Text { common, .. })
             | ftd::Element::Boolean(ftd::Text { common, .. })
             | ftd::Element::Decimal(ftd::Text { common, .. })
-            | ftd::Element::Scene(ftd::Scene { common, .. }) => common,
+            | ftd::Element::Scene(ftd::Scene { common, .. })
+            | ftd::Element::Grid(ftd::Grid { common, .. }) => common,
             ftd::Element::Null => return,
         }
         .condition = condition;
@@ -654,7 +707,8 @@ impl Element {
             | ftd::Element::Integer(ftd::Text { common, .. })
             | ftd::Element::Boolean(ftd::Text { common, .. })
             | ftd::Element::Decimal(ftd::Text { common, .. })
-            | ftd::Element::Scene(ftd::Scene { common, .. }) => common,
+            | ftd::Element::Scene(ftd::Scene { common, .. })
+            | ftd::Element::Grid(ftd::Grid { common, .. }) => common,
             ftd::Element::Null => return,
         }
         .is_not_visible = is_not_visible;
@@ -673,7 +727,8 @@ impl Element {
             | ftd::Element::Integer(ftd::Text { common, .. })
             | ftd::Element::Boolean(ftd::Text { common, .. })
             | ftd::Element::Decimal(ftd::Text { common, .. })
-            | ftd::Element::Scene(ftd::Scene { common, .. }) => common,
+            | ftd::Element::Scene(ftd::Scene { common, .. })
+            | ftd::Element::Grid(ftd::Grid { common, .. }) => common,
             ftd::Element::Null => return,
         }
         .locals = locals;
@@ -692,7 +747,8 @@ impl Element {
             | ftd::Element::Integer(ftd::Text { common, .. })
             | ftd::Element::Boolean(ftd::Text { common, .. })
             | ftd::Element::Decimal(ftd::Text { common, .. })
-            | ftd::Element::Scene(ftd::Scene { common, .. }) => common,
+            | ftd::Element::Scene(ftd::Scene { common, .. })
+            | ftd::Element::Grid(ftd::Grid { common, .. }) => common,
             ftd::Element::Null => return,
         }
         .events
@@ -721,6 +777,7 @@ impl Element {
             ftd::Element::Boolean(e) => Some(&mut e.common),
             ftd::Element::Decimal(e) => Some(&mut e.common),
             ftd::Element::Scene(e) => Some(&mut e.common),
+            ftd::Element::Grid(e) => Some(&mut e.common),
             _ => None,
         }
     }
@@ -739,6 +796,7 @@ impl Element {
             ftd::Element::Boolean(e) => Some(&e.common),
             ftd::Element::Decimal(e) => Some(&e.common),
             ftd::Element::Scene(e) => Some(&e.common),
+            ftd::Element::Grid(e) => Some(&e.common),
             _ => None,
         }
     }
@@ -1330,6 +1388,12 @@ pub struct Row {
 
 #[derive(serde::Deserialize, Debug, Default, PartialEq, Clone, serde::Serialize)]
 pub struct Scene {
+    pub container: Container,
+    pub common: Common,
+}
+
+#[derive(serde::Deserialize, Debug, Default, PartialEq, Clone, serde::Serialize)]
+pub struct Grid {
     pub container: Container,
     pub common: Common,
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1344,7 +1344,7 @@ pub struct Common {
     pub position: Position,
     pub inner: bool,
     pub z_index: Option<i64>,
-    pub grid_area: Option<String>,
+    pub slot: Option<String>,
     pub grid_column: Option<String>,
     pub grid_row: Option<String>,
     // TODO: background-image, un-cropped, tiled, tiled{X, Y}

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -344,6 +344,7 @@ impl Element {
                             ..
                         },
                     container,
+                    ..
                 }) => {
                     ftd::Element::get_style_event_dependencies(&container.children, data);
                     if let Some((_, _, external_children)) = &container.external_children {
@@ -448,6 +449,7 @@ impl Element {
                             ..
                         },
                     container,
+                    ..
                 }) => {
                     ftd::Element::get_value_event_dependencies(&container.children, data);
                     if let Some((_, _, external_children)) = &container.external_children {
@@ -531,6 +533,7 @@ impl Element {
                             ..
                         },
                     container,
+                    ..
                 }) => {
                     ftd::Element::get_visible_event_dependencies(&container.children, data);
                     if let Some((_, _, external_children)) = &container.external_children {
@@ -594,6 +597,7 @@ impl Element {
                 | ftd::Element::Grid(ftd::Grid {
                     common: ftd::Common { locals, .. },
                     container,
+                    ..
                 }) => {
                     let mut all_locals = ftd::Element::get_locals(&container.children);
                     for (k, v) in locals {
@@ -1324,6 +1328,9 @@ pub struct Common {
     pub position: Position,
     pub inner: bool,
     pub z_index: Option<i64>,
+    pub grid_area: Option<String>,
+    pub grid_column: Option<String>,
+    pub grid_row: Option<String>,
     // TODO: background-image, un-cropped, tiled, tiled{X, Y}
     // TODO: border-style: solid, dashed, dotted
     // TODO: border-{shadow, glow}
@@ -1394,6 +1401,14 @@ pub struct Scene {
 
 #[derive(serde::Deserialize, Debug, Default, PartialEq, Clone, serde::Serialize)]
 pub struct Grid {
+    pub areas: Option<String>,
+    pub columns: Option<String>,
+    pub rows: Option<String>,
+    pub gap: Option<i64>,
+    pub column_gap: Option<i64>,
+    pub row_gap: Option<i64>,
+    pub inline: bool,
+    pub auto_flow: Option<String>,
     pub container: Container,
     pub common: Common,
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -49,10 +49,12 @@ impl Element {
                 Self::Row(ftd::Row {
                     common: ftd::Common { data_id: id, .. },
                     container,
+                    ..
                 })
                 | Self::Column(ftd::Column {
                     common: ftd::Common { data_id: id, .. },
                     container,
+                    ..
                 })
                 | Self::Scene(ftd::Scene {
                     common: ftd::Common { data_id: id, .. },
@@ -148,6 +150,7 @@ impl Element {
                         children,
                         ..
                     },
+                ..
             })
             | Self::Column(ftd::Column {
                 common: ftd::Common { data_id: id, .. },
@@ -157,6 +160,7 @@ impl Element {
                         children,
                         ..
                     },
+                ..
             })
             | Self::Scene(ftd::Scene {
                 common: ftd::Common { data_id: id, .. },
@@ -317,6 +321,7 @@ impl Element {
                             ..
                         },
                     container,
+                    ..
                 })
                 | ftd::Element::Row(ftd::Row {
                     common:
@@ -326,6 +331,7 @@ impl Element {
                             ..
                         },
                     container,
+                    ..
                 })
                 | ftd::Element::Scene(ftd::Scene {
                     common:
@@ -335,6 +341,7 @@ impl Element {
                             ..
                         },
                     container,
+                    ..
                 })
                 | ftd::Element::Grid(ftd::Grid {
                     common:
@@ -422,6 +429,7 @@ impl Element {
                             ..
                         },
                     container,
+                    ..
                 })
                 | ftd::Element::Row(ftd::Row {
                     common:
@@ -431,6 +439,7 @@ impl Element {
                             ..
                         },
                     container,
+                    ..
                 })
                 | ftd::Element::Scene(ftd::Scene {
                     common:
@@ -440,6 +449,7 @@ impl Element {
                             ..
                         },
                     container,
+                    ..
                 })
                 | ftd::Element::Grid(ftd::Grid {
                     common:
@@ -506,6 +516,7 @@ impl Element {
                             ..
                         },
                     container,
+                    ..
                 })
                 | ftd::Element::Row(ftd::Row {
                     common:
@@ -515,6 +526,7 @@ impl Element {
                             ..
                         },
                     container,
+                    ..
                 })
                 | ftd::Element::Scene(ftd::Scene {
                     common:
@@ -524,6 +536,7 @@ impl Element {
                             ..
                         },
                     container,
+                    ..
                 })
                 | ftd::Element::Grid(ftd::Grid {
                     common:
@@ -585,14 +598,17 @@ impl Element {
                 ftd::Element::Row(ftd::Row {
                     common: ftd::Common { locals, .. },
                     container,
+                    ..
                 })
                 | ftd::Element::Column(ftd::Column {
                     common: ftd::Common { locals, .. },
                     container,
+                    ..
                 })
                 | ftd::Element::Scene(ftd::Scene {
                     common: ftd::Common { locals, .. },
                     container,
+                    ..
                 })
                 | ftd::Element::Grid(ftd::Grid {
                     common: ftd::Common { locals, .. },
@@ -1364,7 +1380,6 @@ pub struct Container {
     pub children: Vec<ftd::Element>,
     pub external_children: Option<(String, Vec<Vec<usize>>, Vec<ftd::Element>)>,
     pub open: (Option<bool>, Option<String>),
-    pub spacing: Option<Spacing>,
     pub wrap: bool,
 }
 
@@ -1390,23 +1405,25 @@ pub struct Image {
 #[derive(serde::Deserialize, Debug, Default, PartialEq, Clone, serde::Serialize)]
 pub struct Row {
     pub container: Container,
+    pub spacing: Option<Spacing>,
     pub common: Common,
 }
 
 #[derive(serde::Deserialize, Debug, Default, PartialEq, Clone, serde::Serialize)]
 pub struct Scene {
     pub container: Container,
+    pub spacing: Option<Spacing>,
     pub common: Common,
 }
 
 #[derive(serde::Deserialize, Debug, Default, PartialEq, Clone, serde::Serialize)]
 pub struct Grid {
-    pub areas: Option<String>,
-    pub columns: Option<String>,
-    pub rows: Option<String>,
-    pub gap: Option<i64>,
-    pub column_gap: Option<i64>,
-    pub row_gap: Option<i64>,
+    pub slots: String,
+    pub slot_widths: Option<String>,
+    pub slot_heights: Option<String>,
+    pub spacing: Option<i64>,
+    pub spacing_vertical: Option<i64>,
+    pub spacing_horizontal: Option<i64>,
     pub inline: bool,
     pub auto_flow: Option<String>,
     pub container: Container,
@@ -1416,6 +1433,7 @@ pub struct Grid {
 #[derive(serde::Deserialize, Debug, PartialEq, Clone, Default, serde::Serialize)]
 pub struct Column {
     pub container: Container,
+    pub spacing: Option<Spacing>,
     pub common: Common,
 }
 


### PR DESCRIPTION
# `ftd.grid` is here 🥳🥳

To understand the grid well, Checkout this [page](https://css-tricks.com/snippets/css/complete-guide-grid/).


## Grid Using Area

This grid layout contains six columns and three rows:

```ftd
-- ftd.grid:
areas: header header header header header header | menu main main main right right | menu footer footer footer footer footer
gap: 10

--- ftd.text: Header
grid-area: header

--- ftd.text: Menu
grid-area: menu

--- ftd.text: Main
grid-area: main

--- ftd.text: Right
grid-area: right

--- ftd.text: Footer
grid-area: footer
```

With a few style more changes, we get the following output

![alt text](https://i.imgur.com/a5jBlH0.png)



## Grid Using Rows and Column

This grid layout contains three columns and two rows:

```ftd
-- ftd.grid:
columns: 100px 50px 100px
rows: 80px auto
column-gap: 10
row-gap: 15

--- ftd.text: 11
grid-column: 1 / 2
grid-row: 1 / 2

--- ftd.text: 12
grid-column: 2 / 3
grid-row: 1 / 2

--- ftd.text: 13
grid-column: 3 / 4
grid-row: 1 / 2

--- ftd.text: 21
grid-column: 1 / 2
grid-row: 2 / 3

--- ftd.text: 22
grid-column: 2 / 3
grid-row: 2 / 3

--- ftd.text: 23
grid-column: 3 / 4
grid-row: 2 / 3
```

With a few style more changes, we get the following output

![alt text](https://i.imgur.com/Lrfaigr.png)

## Grid Using Area With An Empty Grid Cell

This grid layout contains four columns and three rows:

```ftd
-- ftd.grid:
areas: header header header header | main main . sidebar | footer footer footer footer
gap: 10

--- ftd.text: Header
grid-area: header

--- ftd.text: Main
grid-area: main

--- ftd.text: Sidebar
grid-area: sidebar

--- ftd.text: Footer
grid-area: footer
```

With a few style more changes, we get the following output

![alt text](https://i.imgur.com/mA4mbi6.png)

## Grid Row Auto Flow

This grid layout contains five columns and two rows:

```ftd
-- ftd.grid:
columns: 60px 60px 60px 60px 60px
rows: 30px 30px
column-gap: 10
row-gap: 15
auto-flow: row

--- ftd.text: 11
grid-column: 1
grid-row: 1 / 3

--- ftd.text: 12

--- ftd.text: 13

--- ftd.text: 14

--- ftd.text: 15
grid-column: 5
grid-row: 1 / 3
```

With a few style more changes, we get the following output


![alt text](https://i.imgur.com/pi20KHG.png)


## Grid Column Auto Flow

This grid layout contains five columns and two rows:

```ftd
-- ftd.grid:
columns: 60px 60px 60px 60px 60px
rows: 30px 30px
column-gap: 10
row-gap: 15
auto-flow: column

--- ftd.text: 11
grid-column: 1
grid-row: 1 / 3

--- ftd.text: 12

--- ftd.text: 13

--- ftd.text: 14

--- ftd.text: 15
grid-column: 5
grid-row: 1 / 3
```

With a few style more changes, we get the following output

![alt text](https://i.imgur.com/5OkxNff.png)