### PR TITLE
Fixes: Resolve name for all references (that starts with `$`) and remove root_name from all the functions

### DIFF
--- a/examples/record.ftd
+++ b/examples/record.ftd
@@ -13,6 +13,8 @@ color if $bool: red
 
 -- ftd.text: $amitu-data.name
 
+-- ftd.text: $amitu-data.phone
+
 -- ftd.text: $lib.acme.name
 
 -- ftd.text: $obj.name

--- a/examples/record.ftd
+++ b/examples/record.ftd
@@ -4,7 +4,10 @@
 
 -- ftd.text: $lib.amitu.address.first-line
 
--- ftd.text: $lib.amitu.address.city-detail.name
+-- boolean bool: true
+
+-- ftd.text foo: $lib.amitu.address.city-detail.name
+color if $bool: red
 
 -- lib.lead.individual amitu-data: Amit Upadhyay
 

--- a/examples/test.ftd
+++ b/examples/test.ftd
@@ -1,0 +1,3 @@
+-- import: record
+
+-- record.foo:

--- a/src/component.rs
+++ b/src/component.rs
@@ -527,7 +527,8 @@ impl ChildComponent {
             name,
             doc,
         )?;
-        let (local_arguments, inherits) = read_arguments(p1, name, &root.arguments, doc)?;
+        let (local_arguments, inherits) =
+            read_arguments(p1, name, &root.arguments, arguments, doc)?;
 
         let mut all_arguments = local_arguments.clone();
         all_arguments.extend(arguments.clone());
@@ -1578,8 +1579,13 @@ impl Component {
         let name = var_data.name;
         let root = var_data.kind;
         let root_component = doc.get_component(p1.line_number, root.as_str())?;
-        let (arguments, inherits) =
-            read_arguments(&p1.header, root.as_str(), &root_component.arguments, doc)?;
+        let (arguments, inherits) = read_arguments(
+            &p1.header,
+            root.as_str(),
+            &root_component.arguments,
+            &Default::default(),
+            doc,
+        )?;
 
         assert_no_extra_properties(
             p1.line_number,
@@ -2370,7 +2376,7 @@ pub fn read_properties(
             continue;
         }
         let (conditional_vector, source) = match (
-            p1.conditional_str(doc.name, line_number, name),
+            p1.conditional_str(doc, line_number, name, arguments),
             kind.inner(),
         ) {
             (Ok(v), _) => (
@@ -2591,6 +2597,7 @@ fn read_arguments(
     p1: &ftd::p1::Header,
     root: &str,
     root_arguments: &std::collections::BTreeMap<String, ftd::p2::Kind>,
+    arguments: &std::collections::BTreeMap<String, ftd::p2::Kind>,
     doc: &ftd::p2::TDoc,
 ) -> ftd::p1::Result<(
     std::collections::BTreeMap<String, ftd::p2::Kind>,
@@ -2636,7 +2643,7 @@ fn read_arguments(
                 }
             }
         } else {
-            ftd::p2::Kind::for_variable(i.to_owned(), k, option_v, doc, None)?
+            ftd::p2::Kind::for_variable(i.to_owned(), k, option_v, doc, None, arguments)?
         };
         if let ftd::p2::Kind::UI {
             default: Some((_, h)),

--- a/src/component.rs
+++ b/src/component.rs
@@ -592,7 +592,6 @@ impl ChildComponent {
                         doc,
                         arguments,
                         None,
-                        None,
                     ) {
                         properties.insert(
                             "value".to_string(),
@@ -2058,7 +2057,6 @@ pub fn recursive_child_component(
         doc,
         arguments,
         None,
-        None,
     )?;
 
     let recursive_kind = if let ftd::p2::Kind::List { kind, .. } = recursive_property_value.kind() {
@@ -2223,7 +2221,6 @@ pub fn recursive_child_component(
             None,
             doc,
             &arguments,
-            None,
             None,
         )?;
         Ok(ftd::component::Property {
@@ -2449,7 +2446,6 @@ pub fn read_properties(
                 doc,
                 arguments,
                 Some(source.clone()),
-                None,
             )?;
             let nested_properties = if let ftd::PropertyValue::Reference {
                 kind: ftd::p2::Kind::UI { .. },
@@ -2577,7 +2573,6 @@ fn root_properties_from_inherits(
             None,
             doc,
             arguments,
-            None,
             None,
         )?;
         root_properties.insert(

--- a/src/execute_doc.rs
+++ b/src/execute_doc.rs
@@ -9,7 +9,6 @@ pub struct ExecuteDoc<'a> {
         String,
         Vec<std::collections::BTreeMap<String, ftd::Value>>,
     >,
-    pub root_name: Option<&'a str>,
 }
 
 impl<'a> ExecuteDoc<'a> {
@@ -140,7 +139,6 @@ impl<'a> ExecuteDoc<'a> {
                                     &f.properties,
                                     self.arguments,
                                     &doc,
-                                    None,
                                 )?,
                                 doc.name,
                                 f.line_number,
@@ -162,7 +160,6 @@ impl<'a> ExecuteDoc<'a> {
                         self.arguments,
                         self.invocations,
                         true,
-                        self.root_name,
                         all_locals,
                         &local_container,
                         new_id.clone(),
@@ -189,7 +186,6 @@ impl<'a> ExecuteDoc<'a> {
                         self.arguments,
                         self.invocations,
                         true,
-                        self.root_name,
                         all_locals,
                         &local_container,
                     )?;

--- a/src/p1/header.rs
+++ b/src/p1/header.rs
@@ -248,12 +248,14 @@ impl Header {
 
     pub fn conditional_str(
         &self,
-        doc_id: &str,
+        doc: &ftd::p2::TDoc,
         line_number: usize,
         name: &str,
+        arguments: &std::collections::BTreeMap<String, ftd::p2::Kind>,
     ) -> Result<Vec<(usize, String, Option<&str>)>> {
         let mut conditional_vector = vec![];
         for (idx, (_, k, v)) in self.0.iter().enumerate() {
+            let v = doc.resolve_reference_name(line_number, v, arguments)?;
             if k == name {
                 conditional_vector.push((idx, v.to_string(), None));
             }
@@ -268,7 +270,7 @@ impl Header {
         }
         if conditional_vector.is_empty() {
             Err(Error::NotFound {
-                doc_id: doc_id.to_string(),
+                doc_id: doc.name.to_string(),
                 line_number,
                 key: format!("`{}` header is missing", name),
             })

--- a/src/p2/element.rs
+++ b/src/p2/element.rs
@@ -6,7 +6,6 @@ pub fn common_from_properties(
     is_child: bool,
     events: &[ftd::p2::Event],
     all_locals: &mut ftd::Map,
-    root_name: Option<&str>,
     reference: Option<String>,
 ) -> ftd::p1::Result<ftd::Common> {
     let submit = ftd::p2::utils::string_optional("submit", properties, doc.name, 0)?;
@@ -90,7 +89,7 @@ pub fn common_from_properties(
         locals: Default::default(),
         condition: cond,
         is_not_visible: !is_visible,
-        events: ftd::p2::Event::get_events(0, events, all_locals, properties, doc, root_name)?,
+        events: ftd::p2::Event::get_events(0, events, all_locals, properties, doc)?,
         reference,
         region: ftd::Region::from(
             ftd::p2::utils::string_optional("region", properties, doc.name, 0)?,
@@ -594,7 +593,6 @@ pub fn image_from_properties(
     is_child: bool,
     events: &[ftd::p2::Event],
     all_locals: &mut ftd::Map,
-    root_name: Option<&str>,
 ) -> ftd::p1::Result<ftd::Image> {
     let (src, reference) =
         ftd::p2::utils::string_and_ref(0, "src", properties_with_ref, all_locals, doc.name)?;
@@ -604,7 +602,7 @@ pub fn image_from_properties(
         description: ftd::p2::utils::string_optional("description", properties, doc.name, 0)?
             .unwrap_or_else(|| "".to_string()),
         common: common_from_properties(
-            properties, doc, condition, is_child, events, all_locals, root_name, reference,
+            properties, doc, condition, is_child, events, all_locals, reference,
         )?,
         crop: ftd::p2::utils::bool_with_default("crop", false, properties, doc.name, 0)?,
     })
@@ -643,12 +641,11 @@ pub fn row_from_properties(
     is_child: bool,
     events: &[ftd::p2::Event],
     all_locals: &mut ftd::Map,
-    root_name: Option<&str>,
 ) -> ftd::p1::Result<ftd::Row> {
     let properties = &ftd::p2::utils::properties(properties_with_ref);
     Ok(ftd::Row {
         common: common_from_properties(
-            properties, doc, condition, is_child, events, all_locals, root_name, None,
+            properties, doc, condition, is_child, events, all_locals, None,
         )?,
         container: container_from_properties(properties, doc)?,
         spacing: ftd::Spacing::from(ftd::p2::utils::string_optional(
@@ -690,12 +687,11 @@ pub fn column_from_properties(
     is_child: bool,
     events: &[ftd::p2::Event],
     all_locals: &mut ftd::Map,
-    root_name: Option<&str>,
 ) -> ftd::p1::Result<ftd::Column> {
     let properties = &ftd::p2::utils::properties(properties_with_ref);
     Ok(ftd::Column {
         common: common_from_properties(
-            properties, doc, condition, is_child, events, all_locals, root_name, None,
+            properties, doc, condition, is_child, events, all_locals, None,
         )?,
         container: container_from_properties(properties, doc)?,
         spacing: ftd::Spacing::from(ftd::p2::utils::string_optional(
@@ -795,7 +791,6 @@ pub fn iframe_from_properties(
     is_child: bool,
     events: &[ftd::p2::Event],
     all_locals: &mut ftd::Map,
-    root_name: Option<&str>,
 ) -> ftd::p1::Result<ftd::IFrame> {
     let properties = &ftd::p2::utils::properties(properties_with_ref);
     let src = match (
@@ -812,7 +807,7 @@ pub fn iframe_from_properties(
     Ok(ftd::IFrame {
         src,
         common: common_from_properties(
-            properties, doc, condition, is_child, events, all_locals, root_name, None,
+            properties, doc, condition, is_child, events, all_locals, None,
         )?,
     })
 }
@@ -824,7 +819,6 @@ pub fn iframe_from_properties(
     is_child: bool,
     events: &[ftd::p2::Event],
     all_locals: &mut ftd::Map,
-    root_name: Option<&str>,
 ) -> ftd::p1::Result<ftd::Text> {
     let properties = &ftd::p2::utils::properties(properties_with_ref);
 
@@ -853,7 +847,7 @@ pub fn iframe_from_properties(
             ftd::markdown_line(text.as_str())
         },
         common: common_from_properties(
-            properties, doc, condition, is_child, events, all_locals, root_name, reference,
+            properties, doc, condition, is_child, events, all_locals, reference,
         )?,
         text_align: ftd::TextAlign::from(
             ftd::p2::utils::string_optional("text-align", properties, doc.name, 0)?,
@@ -878,7 +872,6 @@ pub fn text_block_from_properties(
     is_child: bool,
     events: &[ftd::p2::Event],
     all_locals: &mut ftd::Map,
-    root_name: Option<&str>,
 ) -> ftd::p1::Result<ftd::TextBlock> {
     let properties = &ftd::p2::utils::properties(properties_with_ref);
 
@@ -907,7 +900,7 @@ pub fn text_block_from_properties(
             ftd::markdown_line(text.as_str())
         },
         common: common_from_properties(
-            properties, doc, condition, is_child, events, all_locals, root_name, reference,
+            properties, doc, condition, is_child, events, all_locals, reference,
         )?,
         text_align: ftd::TextAlign::from(
             ftd::p2::utils::string_optional("text-align", properties, doc.name, 0)?,
@@ -932,7 +925,6 @@ pub fn code_from_properties(
     is_child: bool,
     events: &[ftd::p2::Event],
     all_locals: &mut ftd::Map,
-    root_name: Option<&str>,
 ) -> ftd::p1::Result<ftd::Code> {
     let properties = &ftd::p2::utils::properties(properties_with_ref);
 
@@ -971,7 +963,7 @@ pub fn code_from_properties(
             doc.name,
         )?,
         common: common_from_properties(
-            properties, doc, condition, is_child, events, all_locals, root_name, reference,
+            properties, doc, condition, is_child, events, all_locals, reference,
         )?,
         text_align: ftd::TextAlign::from(
             ftd::p2::utils::string_optional("text-align", properties, doc.name, 0)?,
@@ -996,7 +988,6 @@ pub fn integer_from_properties(
     is_child: bool,
     events: &[ftd::p2::Event],
     all_locals: &mut ftd::Map,
-    root_name: Option<&str>,
 ) -> ftd::p1::Result<ftd::Text> {
     let properties = &ftd::p2::utils::properties(properties_with_ref);
     let font_str = ftd::p2::utils::string_optional("font", properties, doc.name, 0)?;
@@ -1025,7 +1016,7 @@ pub fn integer_from_properties(
         text: ftd::markdown_line(text.as_str()),
         line: false,
         common: common_from_properties(
-            properties, doc, condition, is_child, events, all_locals, root_name, reference,
+            properties, doc, condition, is_child, events, all_locals, reference,
         )?,
         text_align: ftd::TextAlign::from(
             ftd::p2::utils::string_optional("text-align", properties, doc.name, 0)?,
@@ -1050,7 +1041,6 @@ pub fn decimal_from_properties(
     is_child: bool,
     events: &[ftd::p2::Event],
     all_locals: &mut ftd::Map,
-    root_name: Option<&str>,
 ) -> ftd::p1::Result<ftd::Text> {
     let properties = &ftd::p2::utils::properties(properties_with_ref);
     let font_str = ftd::p2::utils::string_optional("font", properties, doc.name, 0)?;
@@ -1079,7 +1069,7 @@ pub fn decimal_from_properties(
         text: ftd::markdown_line(text.as_str()),
         line: false,
         common: common_from_properties(
-            properties, doc, condition, is_child, events, all_locals, root_name, reference,
+            properties, doc, condition, is_child, events, all_locals, reference,
         )?,
         text_align: ftd::TextAlign::from(
             ftd::p2::utils::string_optional("text-align", properties, doc.name, 0)?,
@@ -1123,7 +1113,6 @@ pub fn boolean_from_properties(
     is_child: bool,
     events: &[ftd::p2::Event],
     all_locals: &mut ftd::Map,
-    root_name: Option<&str>,
 ) -> ftd::p1::Result<ftd::Text> {
     let properties = &ftd::p2::utils::properties(properties_with_ref);
     let font_str = ftd::p2::utils::string_optional("font", properties, doc.name, 0)?;
@@ -1151,7 +1140,7 @@ pub fn boolean_from_properties(
         text: ftd::markdown_line(text.as_str()),
         line: false,
         common: common_from_properties(
-            properties, doc, condition, is_child, events, all_locals, root_name, reference,
+            properties, doc, condition, is_child, events, all_locals, reference,
         )?,
         text_align: ftd::TextAlign::from(
             ftd::p2::utils::string_optional("text-align", properties, doc.name, 0)?,
@@ -1557,12 +1546,11 @@ pub fn input_from_properties(
     is_child: bool,
     events: &[ftd::p2::Event],
     all_locals: &mut ftd::Map,
-    root_name: Option<&str>,
 ) -> ftd::p1::Result<ftd::Input> {
     let properties = &ftd::p2::utils::properties(properties_with_ref);
     Ok(ftd::Input {
         common: common_from_properties(
-            properties, doc, condition, is_child, events, all_locals, root_name, None,
+            properties, doc, condition, is_child, events, all_locals, None,
         )?,
         placeholder: ftd::p2::utils::string_optional("placeholder", properties, doc.name, 0)?,
     })
@@ -1575,12 +1563,11 @@ pub fn scene_from_properties(
     is_child: bool,
     events: &[ftd::p2::Event],
     all_locals: &mut ftd::Map,
-    root_name: Option<&str>,
 ) -> ftd::p1::Result<ftd::Scene> {
     let properties = &ftd::p2::utils::properties(properties_with_ref);
     Ok(ftd::Scene {
         common: common_from_properties(
-            properties, doc, condition, is_child, events, all_locals, root_name, None,
+            properties, doc, condition, is_child, events, all_locals, None,
         )?,
         container: container_from_properties(properties, doc)?,
         spacing: ftd::Spacing::from(ftd::p2::utils::string_optional(
@@ -1596,7 +1583,6 @@ pub fn grid_from_properties(
     is_child: bool,
     events: &[ftd::p2::Event],
     all_locals: &mut ftd::Map,
-    root_name: Option<&str>,
 ) -> ftd::p1::Result<ftd::Grid> {
     let properties = &ftd::p2::utils::properties(properties_with_ref);
     Ok(ftd::Grid {
@@ -1620,7 +1606,7 @@ pub fn grid_from_properties(
             0,
         )?,
         common: common_from_properties(
-            properties, doc, condition, is_child, events, all_locals, root_name, None,
+            properties, doc, condition, is_child, events, all_locals, None,
         )?,
         container: container_from_properties(properties, doc)?,
         inline: ftd::p2::utils::bool_with_default("inline", false, properties, doc.name, 0)?,
@@ -1635,7 +1621,6 @@ pub fn markup_from_properties(
     is_child: bool,
     events: &[ftd::p2::Event],
     all_locals: &mut ftd::Map,
-    root_name: Option<&str>,
 ) -> ftd::p1::Result<ftd::Markups> {
     let properties = &ftd::p2::utils::properties(properties_with_ref);
     let (value, source, reference) = ftd::p2::utils::string_and_source_and_ref(
@@ -1659,7 +1644,7 @@ pub fn markup_from_properties(
     Ok(ftd::Markups {
         text: ftd::markdown_line(value.as_str()),
         common: common_from_properties(
-            properties, doc, condition, is_child, events, all_locals, root_name, reference,
+            properties, doc, condition, is_child, events, all_locals, reference,
         )?,
         children: vec![],
         line: source != ftd::TextSource::Body,

--- a/src/p2/event.rs
+++ b/src/p2/event.rs
@@ -12,15 +12,13 @@ impl Event {
         property: &std::collections::BTreeMap<String, Vec<ftd::PropertyValue>>,
         arguments: &std::collections::BTreeMap<String, ftd::Value>,
         doc: &ftd::p2::TDoc,
-        root_name: Option<&str>,
     ) -> ftd::p1::Result<std::collections::BTreeMap<String, Vec<String>>> {
         let mut property_string: std::collections::BTreeMap<String, Vec<String>> =
             Default::default();
         for (s, property_values) in property {
             let mut property_values_string = vec![];
             for property_value in property_values {
-                let value =
-                    property_value.resolve_with_root(line_number, arguments, doc, root_name)?;
+                let value = property_value.resolve(line_number, arguments, doc)?;
                 if let Some(v) = value.to_string() {
                     property_values_string.push(v);
                 } else {
@@ -42,7 +40,6 @@ impl Event {
         all_locals: &mut ftd::Map,
         arguments: &std::collections::BTreeMap<String, ftd::Value>,
         doc: &ftd::p2::TDoc,
-        root_name: Option<&str>,
     ) -> ftd::p1::Result<Vec<ftd::Event>> {
         let arguments = {
             //remove properties
@@ -87,7 +84,6 @@ impl Event {
                         &e.action.parameters,
                         &arguments,
                         doc,
-                        root_name,
                     )?,
                 },
             });

--- a/src/p2/event.rs
+++ b/src/p2/event.rs
@@ -368,7 +368,6 @@ impl Action {
                                 doc,
                                 arguments,
                                 None,
-                                None,
                             )?);
                             idx += 1;
                         }
@@ -405,7 +404,6 @@ impl Action {
                     doc,
                     arguments,
                     None,
-                    None,
                 )?;
                 let kind = ftd::PropertyValue::Value {
                     value: ftd::variable::Value::String {
@@ -437,15 +435,8 @@ impl Action {
             arguments: &std::collections::BTreeMap<String, ftd::p2::Kind>,
             kind: Option<ftd::p2::Kind>,
         ) -> ftd::p1::Result<(String, ftd::p2::Kind)> {
-            let pv = ftd::PropertyValue::resolve_value(
-                line_number,
-                &value,
-                kind,
-                doc,
-                arguments,
-                None,
-                None,
-            )?;
+            let pv =
+                ftd::PropertyValue::resolve_value(line_number, &value, kind, doc, arguments, None)?;
             Ok((
                 match pv {
                     ftd::PropertyValue::Reference { ref name, .. } => name.to_string(),

--- a/src/p2/expression.rs
+++ b/src/p2/expression.rs
@@ -287,7 +287,6 @@ impl Boolean {
                     doc,
                     arguments,
                     None,
-                    None,
                 ) {
                     Ok(v) => v,
                     Err(e) => match &loop_already_resolved_property {

--- a/src/p2/expression.rs
+++ b/src/p2/expression.rs
@@ -173,8 +173,12 @@ impl Boolean {
         left_right_resolved_property: (Option<ftd::PropertyValue>, Option<ftd::PropertyValue>),
         line_number: usize,
     ) -> ftd::p1::Result<Self> {
-        let (boolean, left, right) =
+        let (boolean, mut left, mut right) =
             ftd::p2::Boolean::boolean_left_right(line_number, expr, doc.name)?;
+        left = doc.resolve_reference_name(line_number, left.as_str(), arguments)?;
+        if let Some(ref r) = right {
+            right = doc.resolve_reference_name(line_number, r, arguments).ok();
+        }
         return Ok(match boolean.as_str() {
             "Literal" => Boolean::Literal {
                 value: left == "true",

--- a/src/p2/interpreter.rs
+++ b/src/p2/interpreter.rs
@@ -8791,7 +8791,7 @@ mod test {
                 text: ftd::markdown_line("Software developer working at fifthtry."),
                 size: Some(20),
                 common: ftd::Common {
-                    reference: Some(s("abrar.bio")),
+                    reference: Some(s("foo/bar#abrar.bio")),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -8993,7 +8993,7 @@ mod test {
                 text: ftd::markdown_line("Amit Upadhyay"),
                 line: true,
                 common: ftd::Common {
-                    reference: Some(s("amitu.name")),
+                    reference: Some(s("foo/bar#amitu.name")),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -9004,7 +9004,7 @@ mod test {
                 text: ftd::markdown_line("1000"),
                 line: true,
                 common: ftd::Common {
-                    reference: Some(s("amitu.phone")),
+                    reference: Some(s("foo/bar#amitu.phone")),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -9016,7 +9016,7 @@ mod test {
                 line: true,
                 size: Some(50),
                 common: ftd::Common {
-                    reference: Some(s("acme.contact")),
+                    reference: Some(s("foo/bar#acme.contact")),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -10527,7 +10527,7 @@ mod test {
     }
 
     #[test]
-    fn action_increment_decrement_condition() {
+    fn action_increment_decrement_condition_1() {
         let mut main = super::default_column();
         main.container
             .children

--- a/src/p2/interpreter.rs
+++ b/src/p2/interpreter.rs
@@ -8700,7 +8700,7 @@ mod test {
                             ftd::PropertyValue::Reference {
                                 name: s("foo/bar#default-age"),
                                 kind: ftd::p2::Kind::Integer {
-                                    default: Some(s("$default-age")),
+                                    default: Some(s("$foo/bar#default-age")),
                                 },
                             },
                         ),
@@ -8763,7 +8763,7 @@ mod test {
                     (
                         s("age"),
                         ftd::p2::Kind::Integer {
-                            default: Some(s("$default-age")),
+                            default: Some(s("$foo/bar#default-age")),
                         },
                     ),
                     (
@@ -8908,12 +8908,12 @@ mod test {
                 arguments: std::array::IntoIter::new([
                     (
                         s("name"),
-                        ftd::p2::Kind::string().set_default(Some(s("$default-name"))),
+                        ftd::p2::Kind::string().set_default(Some(s("$foo/bar#default-name"))),
                     ),
                     (
                         s("text-size"),
                         ftd::p2::Kind::Integer {
-                            default: Some(s("$default-size")),
+                            default: Some(s("$foo/bar#default-size")),
                         },
                     ),
                 ])
@@ -8931,7 +8931,7 @@ mod test {
                                         name: s("text-size"),
                                         kind: ftd::p2::Kind::Optional {
                                             kind: Box::new(ftd::p2::Kind::Integer {
-                                                default: Some(s("$default-size")),
+                                                default: Some(s("$foo/bar#default-size")),
                                             }),
                                         },
                                     }),
@@ -8945,7 +8945,7 @@ mod test {
                                     default: Some(ftd::PropertyValue::Variable {
                                         name: s("name"),
                                         kind: ftd::p2::Kind::caption_or_body()
-                                            .set_default(Some(s("$default-name"))),
+                                            .set_default(Some(s("$foo/bar#default-name"))),
                                     }),
                                     conditions: vec![],
                                     ..Default::default()
@@ -9092,7 +9092,7 @@ mod test {
                             ftd::PropertyValue::Reference {
                                 name: s("foo/bar#default-phone"),
                                 kind: ftd::p2::Kind::string()
-                                    .set_default(Some(s("$default-phone"))),
+                                    .set_default(Some(s("$foo/bar#default-phone"))),
                             },
                         ),
                     ])
@@ -9123,7 +9123,8 @@ mod test {
                             (s("name"), ftd::p2::Kind::caption()),
                             (
                                 s("phone"),
-                                ftd::p2::Kind::string().set_default(Some(s("$default-phone"))),
+                                ftd::p2::Kind::string()
+                                    .set_default(Some(s("$foo/bar#default-phone"))),
                             ),
                         ])
                         .collect(),

--- a/src/p2/kind.rs
+++ b/src/p2/kind.rs
@@ -463,6 +463,18 @@ impl Kind {
         doc: &ftd::p2::TDoc,
         object_kind: Option<(&str, Self)>,
     ) -> ftd::p1::Result<Self> {
+        // resolve the value
+        let default = {
+            let mut default = default.clone();
+            if let Some(ref v) = default {
+                if let Some(v) = v.strip_prefix('$') {
+                    let s = doc.resolve_name(line_number, v)?;
+                    default = Some(format!("${}", s));
+                }
+            }
+            default
+        };
+
         let var_data =
             ftd::variable::VariableData::get_name_kind(s, doc, line_number, vec![].as_slice())?;
 

--- a/src/p2/kind.rs
+++ b/src/p2/kind.rs
@@ -459,15 +459,13 @@ impl Kind {
         default: Option<String>,
         doc: &ftd::p2::TDoc,
         object_kind: Option<(&str, Self)>,
+        arguments: &std::collections::BTreeMap<String, ftd::p2::Kind>,
     ) -> ftd::p1::Result<Self> {
         // resolve the value
         let default = {
             let mut default = default.clone();
             if let Some(ref v) = default {
-                if let Some(v) = v.strip_prefix('$') {
-                    let s = doc.resolve_name(line_number, v)?;
-                    default = Some(format!("${}", s));
-                }
+                default = Some(doc.resolve_reference_name(line_number, v, arguments)?);
             }
             default
         };

--- a/src/p2/kind.rs
+++ b/src/p2/kind.rs
@@ -461,9 +461,9 @@ impl Kind {
         object_kind: Option<(&str, Self)>,
         arguments: &std::collections::BTreeMap<String, ftd::p2::Kind>,
     ) -> ftd::p1::Result<Self> {
-        // resolve the value
         let default = {
-            let mut default = default.clone();
+            // resolve the default value
+            let mut default = default;
             if let Some(ref v) = default {
                 default = Some(doc.resolve_reference_name(line_number, v, arguments)?);
             }

--- a/src/p2/kind.rs
+++ b/src/p2/kind.rs
@@ -259,7 +259,6 @@ impl Kind {
         }
     }
 
-    #[allow(clippy::too_many_arguments)]
     pub fn read_section(
         &self,
         line_number: usize,
@@ -268,7 +267,6 @@ impl Kind {
         p1_body: &Option<(usize, String)>,
         name: &str,
         doc: &ftd::p2::TDoc,
-        root_name: Option<&str>,
     ) -> ftd::p1::Result<ftd::PropertyValue> {
         let (v, source) = match p1.str_optional(doc.name, line_number, name)? {
             Some(v) => (v.to_string(), ftd::TextSource::Header),
@@ -332,7 +330,6 @@ impl Kind {
                 doc,
                 &Default::default(),
                 None,
-                root_name,
             );
         }
 

--- a/src/p2/record.rs
+++ b/src/p2/record.rs
@@ -120,22 +120,14 @@ impl Record {
                         )
                     }
                 },
-                (Err(ftd::p1::Error::NotFound { .. }), _) => {
-                    let root_name = if let Some((root, _)) = self.name.split_once('#') {
-                        Some(root)
-                    } else {
-                        None
-                    };
-                    kind.read_section(
-                        p1.line_number,
-                        &p1.header,
-                        &p1.caption,
-                        &p1.body_without_comment(),
-                        name,
-                        doc,
-                        root_name,
-                    )?
-                }
+                (Err(ftd::p1::Error::NotFound { .. }), _) => kind.read_section(
+                    p1.line_number,
+                    &p1.header,
+                    &p1.caption,
+                    &p1.body_without_comment(),
+                    name,
+                    doc,
+                )?,
                 (
                     Err(ftd::p1::Error::MoreThanOneSubSections { .. }),
                     ftd::p2::Kind::List {
@@ -163,7 +155,6 @@ impl Record {
                                     &s.body_without_comment(),
                                     s.name.as_str(),
                                     doc,
-                                    None,
                                 )? {
                                     ftd::PropertyValue::Value { value: v } => v,
                                     _ => unimplemented!(),
@@ -227,7 +218,6 @@ impl Record {
                     &p1.body_without_comment(),
                     name,
                     doc,
-                    None,
                 )?,
             );
         }

--- a/src/p2/record.rs
+++ b/src/p2/record.rs
@@ -293,7 +293,14 @@ impl Record {
             };
             fields.insert(
                 var_data.name.to_string(),
-                ftd::p2::Kind::for_variable(i.to_owned(), k, v, doc, Some(object_kind.clone()))?,
+                ftd::p2::Kind::for_variable(
+                    i.to_owned(),
+                    k,
+                    v,
+                    doc,
+                    Some(object_kind.clone()),
+                    &Default::default(),
+                )?,
             );
             order.push(var_data.name.to_string());
         }

--- a/src/p2/utils.rs
+++ b/src/p2/utils.rs
@@ -396,6 +396,21 @@ pub fn decimal_optional(
     }
 }
 
+pub(crate) fn get_doc_name_and_remaining(s: &str) -> ftd::p1::Result<(String, Option<String>)> {
+    let mut part1 = "".to_string();
+    let mut pattern_to_split_at = s.to_string();
+    if let Some((p1, p2)) = s.split_once('#') {
+        part1 = format!("{}#", p1);
+        pattern_to_split_at = p2.to_string();
+    }
+    Ok(if pattern_to_split_at.contains('.') {
+        let (p1, p2) = ftd::p2::utils::split(pattern_to_split_at, ".")?;
+        (format!("{}{}", part1, p1), Some(p2))
+    } else {
+        (s.to_string(), None)
+    })
+}
+
 pub fn split(name: String, split_at: &str) -> ftd::p1::Result<(String, String)> {
     let mut part = name.splitn(2, split_at);
     let part_1 = part.next().unwrap().trim();

--- a/src/rt.rs
+++ b/src/rt.rs
@@ -67,7 +67,6 @@ impl RT {
             instructions: &self.instructions,
             arguments: &Default::default(),
             invocations: &mut invocations,
-            root_name: None,
         }
         .execute(&[], &mut Default::default(), None)?
         .children;

--- a/src/variable.rs
+++ b/src/variable.rs
@@ -21,7 +21,6 @@ impl PropertyValue {
         doc: &ftd::p2::TDoc,
         arguments: &std::collections::BTreeMap<String, ftd::p2::Kind>,
         source: Option<ftd::TextSource>,
-        root_name: Option<&str>,
     ) -> ftd::p1::Result<ftd::PropertyValue> {
         let property_type = if let Some(arg) = value.strip_prefix('$') {
             PropertyType::Variable(arg.to_string())
@@ -55,7 +54,7 @@ impl PropertyValue {
                         },
                         false,
                     ),
-                    None => match doc.get_thing_with_root(line_number, &string, root_name) {
+                    None => match doc.get_thing(line_number, &string) {
                         Ok(ftd::p2::Thing::Variable(v)) => (v.value.kind(), true),
                         Ok(ftd::p2::Thing::Component(_)) => {
                             (ftd::p2::Kind::UI { default: None }, true)

--- a/src/variable.rs
+++ b/src/variable.rs
@@ -164,9 +164,15 @@ impl PropertyValue {
         }
 
         fn get_parts(s: &str) -> ftd::p1::Result<(String, Option<String>)> {
-            Ok(if s.contains('.') {
-                let (p1, p2) = ftd::p2::utils::split(s.to_string(), ".")?;
-                (p1, Some(p2))
+            let mut part1 = "".to_string();
+            let mut pattern_to_split_at = s.to_string();
+            if let Some((p1, p2)) = s.split_once('#') {
+                part1 = p1.to_string();
+                pattern_to_split_at = p2.to_string();
+            }
+            Ok(if pattern_to_split_at.contains('.') {
+                let (p1, p2) = ftd::p2::utils::split(pattern_to_split_at, ".")?;
+                (format!("{}{}", part1, p1), Some(p2))
             } else {
                 (s.to_string(), None)
             })

--- a/src/variable.rs
+++ b/src/variable.rs
@@ -43,7 +43,7 @@ impl PropertyValue {
             PropertyType::Value(value)
         };
 
-        let (part1, part2) = get_parts(&property_type.string())?;
+        let (part1, part2) = ftd::p2::utils::get_doc_name_and_remaining(&property_type.string())?;
 
         return Ok(match property_type {
             PropertyType::Variable(string) | PropertyType::Component { name: string, .. } => {
@@ -160,21 +160,6 @@ impl PropertyValue {
                     | PropertyType::Component { name: s, .. } => s.to_string(),
                 }
             }
-        }
-
-        fn get_parts(s: &str) -> ftd::p1::Result<(String, Option<String>)> {
-            let mut part1 = "".to_string();
-            let mut pattern_to_split_at = s.to_string();
-            if let Some((p1, p2)) = s.split_once('#') {
-                part1 = p1.to_string();
-                pattern_to_split_at = p2.to_string();
-            }
-            Ok(if pattern_to_split_at.contains('.') {
-                let (p1, p2) = ftd::p2::utils::split(pattern_to_split_at, ".")?;
-                (format!("{}{}", part1, p1), Some(p2))
-            } else {
-                (s.to_string(), None)
-            })
         }
 
         fn get_kind(
@@ -498,7 +483,14 @@ impl Variable {
             vec![].as_slice(),
         )?;
         let name = doc.resolve_name(p1.line_number, &var_data.name)?;
-        let kind = ftd::p2::Kind::for_variable(p1.line_number, &p1.name, None, doc, None)?;
+        let kind = ftd::p2::Kind::for_variable(
+            p1.line_number,
+            &p1.name,
+            None,
+            doc,
+            None,
+            &Default::default(),
+        )?;
         if !kind.is_list() {
             return ftd::e2(
                 format!("Expected list found: {:?}", p1),
@@ -605,7 +597,14 @@ impl Variable {
         let name = var_data.name.clone();
 
         if var_data.is_optional() && p1.caption.is_none() && p1.body.is_none() {
-            let kind = ftd::p2::Kind::for_variable(p1.line_number, &p1.name, None, doc, None)?;
+            let kind = ftd::p2::Kind::for_variable(
+                p1.line_number,
+                &p1.name,
+                None,
+                doc,
+                None,
+                &Default::default(),
+            )?;
             return Ok(Variable {
                 name,
                 value: ftd::Value::Optional {
@@ -637,7 +636,14 @@ impl Variable {
                 },
             };
             if var_data.is_optional() {
-                let kind = ftd::p2::Kind::for_variable(p1.line_number, &p1.name, None, doc, None)?;
+                let kind = ftd::p2::Kind::for_variable(
+                    p1.line_number,
+                    &p1.name,
+                    None,
+                    doc,
+                    None,
+                    &Default::default(),
+                )?;
                 value = ftd::Value::Optional {
                     data: Box::new(Some(value)),
                     kind: kind.inner().to_owned(),


### PR DESCRIPTION
1. Store default as the resolved name