### PR TITLE
record reinitialisation working

### DIFF
--- a/examples/record-reinitialisation.ftd
+++ b/examples/record-reinitialisation.ftd
@@ -1,0 +1,26 @@
+-- import: lib
+
+-- record person-detail:
+caption name:
+integer age:
+
+-- person-detail tom: Tom
+age: 30
+
+-- tom.age: 40
+
+-- lib.amitu.address.first-line: Hill Crest Bengaluru
+
+-- ftd.text: $lib.amitu.name
+
+-- ftd.text: $lib.amitu.address.first-line
+
+-- print-person:
+person: $tom
+
+-- ftd.column print-person:
+person-detail person:
+
+--- ftd.text: $person.name
+
+--- ftd.integer: $person.age

--- a/src/p2/interpreter.rs
+++ b/src/p2/interpreter.rs
@@ -279,6 +279,21 @@ impl<'a> Interpreter<'a> {
                             .str_optional(doc.name, p1.line_number, "$processor$")?
                             .is_some())
                 );
+                let (doc_name, remaining) = ftd::p2::utils::get_doc_name_and_remaining(
+                    doc.resolve_name(p1.line_number, p1.name.as_str())?.as_str(),
+                )?;
+                if remaining.is_some()
+                    && p1
+                        .header
+                        .str_optional(doc.name, p1.line_number, "if")?
+                        .is_some()
+                {
+                    return ftd::e2(
+                        "Currently not supporting `if` for field value update.",
+                        doc.name,
+                        p1.line_number,
+                    );
+                }
                 if let Some(expr) = p1.header.str_optional(doc.name, p1.line_number, "if")? {
                     let val = v.get_value(p1, &doc)?;
                     v.conditions.push((
@@ -304,8 +319,8 @@ impl<'a> Interpreter<'a> {
                     v.update_from_p1(p1, &doc)?;
                 }
                 thing.push((
-                    doc.resolve_name(p1.line_number, &p1.name.to_string())?,
-                    ftd::p2::Thing::Variable(v),
+                    doc.resolve_name(p1.line_number, doc_name.as_str())?,
+                    ftd::p2::Thing::Variable(doc.set_value(p1.line_number, p1.name.as_str(), v)?),
                 ));
             } else {
                 // cloning because https://github.com/rust-lang/rust/issues/59159
@@ -440,7 +455,7 @@ impl<'a> Interpreter<'a> {
         Ok(instructions)
     }
 
-    #[cfg(not(feature = "async"))]
+    // #[cfg(not(feature = "async"))]
     fn interpret_(
         &mut self,
         name: &str,
@@ -648,6 +663,21 @@ impl<'a> Interpreter<'a> {
                             .str_optional(doc.name, p1.line_number, "$processor$")?
                             .is_some())
                 );
+                let (doc_name, remaining) = ftd::p2::utils::get_doc_name_and_remaining(
+                    doc.resolve_name(p1.line_number, p1.name.as_str())?.as_str(),
+                )?;
+                if remaining.is_some()
+                    && p1
+                        .header
+                        .str_optional(doc.name, p1.line_number, "if")?
+                        .is_some()
+                {
+                    return ftd::e2(
+                        "Currently not supporting `if` for field value update.",
+                        doc.name,
+                        p1.line_number,
+                    );
+                }
                 if let Some(expr) = p1.header.str_optional(doc.name, p1.line_number, "if")? {
                     let val = v.get_value(p1, &doc)?;
                     v.conditions.push((
@@ -673,8 +703,8 @@ impl<'a> Interpreter<'a> {
                     v.update_from_p1(p1, &doc)?;
                 }
                 thing.push((
-                    doc.resolve_name(p1.line_number, &p1.name.to_string())?,
-                    ftd::p2::Thing::Variable(v),
+                    doc.resolve_name(p1.line_number, doc_name.as_str())?,
+                    ftd::p2::Thing::Variable(doc.set_value(p1.line_number, p1.name.as_str(), v)?),
                 ));
             } else {
                 // cloning because https://github.com/rust-lang/rust/issues/59159

--- a/src/variable.rs
+++ b/src/variable.rs
@@ -467,6 +467,13 @@ impl Value {
         false
     }
 
+    pub fn is_optional(&self) -> bool {
+        if matches!(self, Self::Optional { .. }) {
+            return true;
+        }
+        false
+    }
+
     pub fn is_empty(&self) -> bool {
         if let Self::List { data, .. } = self {
             if data.is_empty() {


### PR DESCRIPTION
With this PR, the variable of record type can independently update any of its field.

Consider the following code

```ftd
-- record person-detail:
caption name:
integer age:

-- person-detail tom: Tom
age: 30

-- tom.age: 40
```

The above code will update the age and set it to 40. This can be convert to following json

```json
{
  "tom": {
     "name": "Tom",
     "age": 40
  }
}
```