### PR TITLE
`background-image` kind: string -> ftd.image-src

### DIFF
--- a/examples/background-image.ftd
+++ b/examples/background-image.ftd
@@ -1,0 +1,41 @@
+-- ftd.image-src src: https://blog.earlymoments.com/wp-content/uploads/2016/03/Mickey_Mouse_group_700x493.jpg
+dark: https://blog.ipleaders.in/wp-content/uploads/2021/07/751589-mickey-mouse.jpg
+
+-- ftd.font-size dsize:
+line-height: 40
+size: 40
+tracking: 0.0
+
+-- ftd.type heading: cursive
+weight: 800
+style: italic
+desktop: $dsize
+mobile: $dsize
+xl: $dsize
+
+-- ftd.color text-color: white
+dark: blue
+
+-- ftd.column:
+padding: 50
+
+-- ftd.text: Responsive Background Image
+role: $heading
+padding-bottom: 20
+
+-- ftd.column:
+background-image: $src
+padding: 100
+
+--- ftd.text: Background Image
+color: $text-color
+
+
+-- ftd.text: Dark Mode
+$on-click$: message-host enable-dark-mode
+
+-- ftd.text: Light Mode
+$on-click$: message-host enable-light-mode
+
+-- ftd.text: System Mode
+$on-click$: message-host enable-system-mode

--- a/examples/comic.ftd
+++ b/examples/comic.ftd
@@ -37,6 +37,12 @@ dark: https://media.githubusercontent.com/media/gramener/comicgen/v1/svg/priyanu
 -- ftd.image-src src9: https://media.githubusercontent.com/media/gramener/comicgen/v1/svg/priyanuova/straight/emotion/laugh.svg
 dark: https://media.githubusercontent.com/media/gramener/comicgen/v1/svg/priyanuova/straight/emotion/laugh.svg
 
+-- ftd.image-src bg-src: https://previews.123rf.com/images/blackspring/blackspring1512/blackspring151200008/49429469-cartoon-forest-background.jpg
+dark: https://previews.123rf.com/images/blackspring/blackspring1512/blackspring151200008/49429469-cartoon-forest-background.jpg
+
+-- ftd.image-src bg-src1: https://image.shutterstock.com/z/stock-&lt;!&ndash;&ndash;&gt;vector-vector-illustration-of-a-beautiful-summer-landscape-143054302.jpg
+dark: https://image.shutterstock.com/z/stock-&lt;!&ndash;&ndash;&gt;vector-vector-illustration-of-a-beautiful-summer-landscape-143054302.jpg
+
 -- ft.h0: Once upon a time...
 
 -- ftd.scene:
@@ -99,7 +105,7 @@ top: 10
 
 
 -- ftd.scene sophie_and_ethan_says:
-background-image: https://previews.123rf.com/images/blackspring/blackspring1512/blackspring151200008/49429469-cartoon-forest-background.jpg
+background-image: $bg-src
 width: 500
 left: 20
 top: 386
@@ -187,7 +193,7 @@ left: 0
 -- ftd.scene import-ethan-scene:
 left: 0
 top: 590
-background-image: https://image.shutterstock.com/z/stock-&lt;!&ndash;&ndash;&gt;vector-vector-illustration-of-a-beautiful-summer-landscape-143054302.jpg
+background-image: $bg-src1
 scale: 0.5
 
 --- comic1.ethan_says:

--- a/examples/comic_scene_crop_scale.ftd
+++ b/examples/comic_scene_crop_scale.ftd
@@ -9,11 +9,14 @@ dark: https://media.githubusercontent.com/media/gramener/comicgen/v1/svg/aryan/p
 -- ftd.image-src src1: https://media.githubusercontent.com/media/gramener/comicgen/v1/svg/aryan/emotion/smile.svg
 dark: https://media.githubusercontent.com/media/gramener/comicgen/v1/svg/aryan/emotion/smile.svg
 
+-- ftd.image-src bg-src: https://image.shutterstock.com/z/stock-&lt;!&ndash;&ndash;&gt;vector-vector-illustration-of-a-beautiful-summer-landscape-143054302.jpg
+dark: https://image.shutterstock.com/z/stock-&lt;!&ndash;&ndash;&gt;vector-vector-illustration-of-a-beautiful-summer-landscape-143054302.jpg
+
 -- ft.h0: Once upon a time...
 
 -- ftd.scene:
 align: center
-background-image: https://image.shutterstock.com/z/stock-&lt;!&ndash;&ndash;&gt;vector-vector-illustration-of-a-beautiful-summer-landscape-143054302.jpg
+background-image: $bg-src
 
 --- ethan_says:
 

--- a/examples/comic_with_scene_without_comicgen.ftd
+++ b/examples/comic_with_scene_without_comicgen.ftd
@@ -9,10 +9,13 @@ dark: https://media.githubusercontent.com/media/gramener/comicgen/v1/svg/aryan/p
 -- ftd.image-src src1: https://media.githubusercontent.com/media/gramener/comicgen/v1/svg/aryan/emotion/sad.svg
 dark: https://media.githubusercontent.com/media/gramener/comicgen/v1/svg/aryan/emotion/sad.svg
 
+-- ftd.image-src bg-src: https://image.shutterstock.com/z/stock-&lt;!&ndash;&ndash;&gt;vector-vector-illustration-of-a-beautiful-summer-landscape-143054302.jpg
+dark: https://image.shutterstock.com/z/stock-&lt;!&ndash;&ndash;&gt;vector-vector-illustration-of-a-beautiful-summer-landscape-143054302.jpg
+
 -- ft.h0: Once upon a time...
 
 -- ftd.scene:
-background-image: https://image.shutterstock.com/z/stock-&lt;!&ndash;&ndash;&gt;vector-vector-illustration-of-a-beautiful-summer-landscape-143054302.jpg
+background-image: $bg-src
 width: 1000
 
 --- ethan-happy-facing-side:

--- a/examples/conditional-attributes.ftd
+++ b/examples/conditional-attributes.ftd
@@ -15,6 +15,9 @@ dark: #6b223a
 -- ftd.color white: white
 dark: white
 
+-- ftd.image-src src: https://www.w3schools.com/cssref/img_tree.gif
+dark: https://www.w3schools.com/cssref/img_tree.gif
+
 -- ftd.text foo:
 body name:
 color if $present: $red
@@ -34,7 +37,7 @@ shadow-color: $green
 shadow-color if $present: $6b223a
 shadow-size if $present: 5
 text: $name
-background-image: https://www.w3schools.com/cssref/img_tree.gif
+background-image: $src
 background-repeat if $present: true
 background-parallax if $present: true
 

--- a/src/html.rs
+++ b/src/html.rs
@@ -380,7 +380,7 @@ impl ftd::Scene {
                             node: s("img"),
                             ..Default::default()
                         };
-                        n.attrs.insert(s("src"), s(img));
+                        n.attrs.insert(s("src"), img.light.to_string());
                         n.attrs.insert(s("alt"), escape("Scene"));
                         n
                     } else {
@@ -1203,7 +1203,7 @@ impl ftd::Common {
             d.insert(s("background-image"), gradient(p, &self.gradient_colors));
         }
         if let Some(p) = &self.background_image {
-            d.insert(s("background-image"), format!("url({})", p));
+            d.insert(s("background-image"), format!("url({})", p.light));
             if self.background_repeat {
                 d.insert(s("background-repeat"), s("repeat"));
             } else {

--- a/src/p2/document.rs
+++ b/src/p2/document.rs
@@ -147,6 +147,7 @@ impl Document {
         ftd::Element::get_visible_event_dependencies(&self.main.container.children, &mut data);
         ftd::Element::get_value_event_dependencies(&self.main.container.children, &mut data);
         ftd::Element::get_style_event_dependencies(&self.main.container.children, &mut data);
+        ftd::Element::get_image_event_dependencies(&self.main.container.children, &mut data);
 
         data.into_iter()
             .filter(|(k, v)| (!v.dependencies.is_empty() || always_include.contains(k)))

--- a/src/p2/interpreter.rs
+++ b/src/p2/interpreter.rs
@@ -4597,7 +4597,10 @@ mod test {
         };
 
         let image = ftd::Image {
-            src: i("/static/home/document-type-min.png"),
+            src: i(
+                "/static/home/document-type-min.png",
+                Some(s("foo/bar#src@0")),
+            ),
             common: ftd::Common {
                 reference: Some(s("foo/bar#src@0")),
                 ..Default::default()
@@ -4795,7 +4798,10 @@ mod test {
             ..Default::default()
         };
         let image = ftd::Image {
-            src: i("/static/home/document-type-min.png"),
+            src: i(
+                "/static/home/document-type-min.png",
+                Some(s("foo/bar#src@0")),
+            ),
             common: ftd::Common {
                 reference: Some(s("foo/bar#src@0")),
                 condition: Some(ftd::Condition {
@@ -4807,7 +4813,7 @@ mod test {
             ..Default::default()
         };
         let second_image = ftd::Image {
-            src: i("second-image.png"),
+            src: i("second-image.png", Some(s("foo/bar#src@1"))),
             common: ftd::Common {
                 reference: Some(s("foo/bar#src@1")),
                 condition: Some(ftd::Condition {
@@ -5141,7 +5147,10 @@ mod test {
             ..Default::default()
         };
         let image = ftd::Image {
-            src: i("/static/home/document-type-min.png"),
+            src: i(
+                "/static/home/document-type-min.png",
+                Some(s("foo/bar#src@0")),
+            ),
             common: ftd::Common {
                 reference: Some(s("foo/bar#src@0")),
                 condition: Some(ftd::Condition {
@@ -5153,7 +5162,7 @@ mod test {
             ..Default::default()
         };
         let second_image = ftd::Image {
-            src: i("second-image.png"),
+            src: i("second-image.png", Some(s("foo/bar#src@1"))),
             common: ftd::Common {
                 reference: Some(s("foo/bar#src@1")),
                 condition: Some(ftd::Condition {
@@ -5165,7 +5174,7 @@ mod test {
             ..Default::default()
         };
         let third_image = ftd::Image {
-            src: i(""),
+            src: i("", Some(s("foo/bar#src@2"))),
             common: ftd::Common {
                 reference: Some(s("foo/bar#src@2")),
                 condition: Some(ftd::Condition {
@@ -5963,7 +5972,7 @@ mod test {
                 spacing: None,
                 container: ftd::Container {
                     children: vec![ftd::Element::Image(ftd::Image {
-                        src: i("foo.png"),
+                        src: i("foo.png", Some(s("foo/bar#src@0"))),
                         common: ftd::Common {
                             reference: Some(s("foo/bar#src@0")),
                             ..Default::default()
@@ -5980,7 +5989,7 @@ mod test {
                 spacing: None,
                 container: ftd::Container {
                     children: vec![ftd::Element::Image(ftd::Image {
-                        src: i("bar.png"),
+                        src: i("bar.png", Some(s("foo/bar#src@1"))),
                         common: ftd::Common {
                             reference: Some(s("foo/bar#src@1")),
                             width: Some(ftd::Length::Px { value: 300 }),
@@ -13725,7 +13734,7 @@ mod test {
         main.container
             .children
             .push(ftd::Element::Image(ftd::Image {
-                src: i("https://www.liveabout.com/thmb/YCJmu1khSJo8kMYM090QCd9W78U=/1250x0/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/powerpuff_girls-56a00bc45f9b58eba4aea61d.jpg"),
+                src: i("https://www.liveabout.com/thmb/YCJmu1khSJo8kMYM090QCd9W78U=/1250x0/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/powerpuff_girls-56a00bc45f9b58eba4aea61d.jpg", Some(s("foo/bar#src@0"))),
                 common: ftd::Common {
                     condition: Some(
                         ftd::Condition {
@@ -13760,7 +13769,10 @@ mod test {
         main.container
             .children
             .push(ftd::Element::Image(ftd::Image {
-                src: i("https://upload.wikimedia.org/wikipedia/en/d/d4/Mickey_Mouse.png"),
+                src: i(
+                    "https://upload.wikimedia.org/wikipedia/en/d/d4/Mickey_Mouse.png",
+                    Some(s("foo/bar#src@1")),
+                ),
                 common: ftd::Common {
                     condition: Some(ftd::Condition {
                         variable: s("foo/bar#count"),
@@ -14899,7 +14911,7 @@ mod test {
                         },
                     ),
                     background_image: Some(
-                        s("https://image.shutterstock.com/z/stock-&lt;!&ndash;&ndash;&gt;vector-vector-illustration-of-a-beautiful-summer-landscape-143054302.jpg"),
+                        i("https://image.shutterstock.com/z/stock-&lt;!&ndash;&ndash;&gt;vector-vector-illustration-of-a-beautiful-summer-landscape-143054302.jpg", Some(s("foo/bar#bg-src"))),
                     ),
                     ..Default::default()
                 }
@@ -14909,8 +14921,11 @@ mod test {
             "foo/bar",
             indoc::indoc!(
                 "
+                -- ftd.image-src bg-src: https://image.shutterstock.com/z/stock-&lt;!&ndash;&ndash;&gt;vector-vector-illustration-of-a-beautiful-summer-landscape-143054302.jpg
+                dark: https://image.shutterstock.com/z/stock-&lt;!&ndash;&ndash;&gt;vector-vector-illustration-of-a-beautiful-summer-landscape-143054302.jpg
+
                 -- ftd.scene:
-                background-image: https://image.shutterstock.com/z/stock-&lt;!&ndash;&ndash;&gt;vector-vector-illustration-of-a-beautiful-summer-landscape-143054302.jpg
+                background-image: $bg-src
                 width: 1000
 
                 --- ftd.text: Hello
@@ -15138,7 +15153,10 @@ mod test {
                     container: ftd::Container {
                         children: vec![
                             ftd::Element::Image(ftd::Image {
-                                src: i("https://www.nilinswap.com/static/img/dp.jpeg"),
+                                src: i(
+                                    "https://www.nilinswap.com/static/img/dp.jpeg",
+                                    Some(s("foo/bar#src0")),
+                                ),
                                 common: ftd::Common {
                                     reference: Some(s("foo/bar#src0")),
                                     ..Default::default()

--- a/src/test.rs
+++ b/src/test.rs
@@ -32,10 +32,11 @@ pub fn s(s: &str) -> String {
     s.to_string()
 }
 
-pub fn i(p: &str) -> ftd::ImageSrc {
+pub fn i(p: &str, reference: Option<String>) -> ftd::ImageSrc {
     ftd::ImageSrc {
         light: s(p),
         dark: s(p),
+        reference,
     }
 }
 


### PR DESCRIPTION
With this PR, the kind/type of `background-image` property changes from `string` to `ftd.image-src`.

Consider the following code:

```ftd
-- ftd.image-src bg-src: 
light: a.jpg
dark: b.jpg

-- ftd.column:
background-image: $bg-src
padding: 100
```

Now background-image becomes responsive on dark-mode switch. In case of light mode, a.jpg would be the background image and in case of dark mode, b.jpg would be the background image.