### PR TITLE
Performance optimization ftd::p2::document::Document::rt_data function

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -104,7 +104,7 @@ fn write(id: &str, doc: String) {
                     .expect("failed to convert document to json")
                     .as_str(),
             )
-            .replace("__ftd__", b.html("main", id).as_str())
+            .replace("__ftd__", doc.html.as_str())
             .replace("__ftd_js__", ftd_js.as_str())
             .replace("__ftd_body_events__", doc.body_events.as_str())
             .replace("__ftd_css__", ftd::css())


### PR DESCRIPTION
This PR considerably reduced the FTD build time by following changes.

1. Merge all event dependencies functions into one function `ftd::Element::get_event_dependencies`.
2. Call`ftd::p2::document::Document::rt_data` only once.
3. Call the most expensive function `ftd::Element::get_dark_mode_dependencies` after fetching all variables dependencies so that scope of variables to look into becomes smaller, hence reducing the execution time.