### PR TITLE
Final duplicate headers

### DIFF
--- a/src/p1/header.rs
+++ b/src/p1/header.rs
@@ -9,7 +9,8 @@ impl Header {
         }
         header
     }
-   pub fn duplicate_header(&self) -> ftd::p1::Result<()> {
+
+    pub fn duplicate_header(&self) -> ftd::p1::Result<()> {
         let mut hm = std::collections::HashMap::new();
         for (ln, k, v) in self.0.iter().filter(|(_, y, _)| !y.starts_with('/')) {
             if hm.contains_key(k) {

--- a/src/p1/header.rs
+++ b/src/p1/header.rs
@@ -9,17 +9,21 @@ impl Header {
         }
         header
     }
-    pub fn duplicate_header(&self, doc_id: &str, line_number: usize) -> ftd::p1::Result<()> {
-        let mut hs = std::collections::HashSet::new();
-        for (_, k, _) in self.0.iter().filter(|(_, y, _)| !y.starts_with('/')) {
-            if hs.contains(k) {
-                return Err(ftd::p1::Error::ParseError {
-                    doc_id: doc_id.to_string(),
-                    line_number,
-                    message: format!("`{}` header is repeated", k),
-                });
+   pub fn duplicate_header(&self) -> ftd::p1::Result<()> {
+        let mut hm = std::collections::HashMap::new();
+        for (ln, k, v) in self.0.iter().filter(|(_, y, _)| !y.starts_with('/')) {
+            if hm.contains_key(k) {
+                let old_value = hm[k];
+                let new_value = v;
+                if old_value == new_value {
+                    return Err(ftd::p1::Error::ParseError {
+                        doc_id: k.to_string(),
+                        line_number: *ln,
+                        message: format!("header is repeated for {}", old_value),
+                    });
+                }
             }
-            hs.insert(k);
+            hm.insert(k, v);
         }
         Ok(())
     }

--- a/src/p1/header.rs
+++ b/src/p1/header.rs
@@ -12,17 +12,19 @@ impl Header {
 
     pub fn duplicate_header(&self) -> ftd::p1::Result<()> {
         let mut hm = std::collections::HashMap::new();
-        for (ln, k, v) in self.0.iter().filter(|(_, y, _)| !y.starts_with('/')) {
+        for (ln, k, v) in self
+            .0
+            .iter()
+            .filter(|(_, y, _)| !y.starts_with('/'))
+            .filter(|(_, y, _)| !y.starts_with('$'))
+            .filter(|(_, y, _)| !y.starts_with('>'))
+        {
             if hm.contains_key(k) {
-                let old_value = hm[k];
-                let new_value = v;
-                if old_value == new_value {
-                    return Err(ftd::p1::Error::ParseError {
-                        doc_id: k.to_string(),
-                        line_number: *ln,
-                        message: format!("header is repeated for {}", old_value),
-                    });
-                }
+                return Err(ftd::p1::Error::ParseError {
+                    doc_id: k.to_string(),
+                    line_number: *ln,
+                    message: format!("{} header is repeated for {}", k, v),
+                });
             }
             hm.insert(k, v);
         }

--- a/src/p1/header.rs
+++ b/src/p1/header.rs
@@ -1,5 +1,3 @@
-pub use ftd::p1::{Error, Result};
-
 #[derive(Debug, PartialEq, Default, Clone, serde::Serialize, serde::Deserialize)]
 pub struct Header(pub Vec<(usize, String, String)>);
 
@@ -10,6 +8,20 @@ impl Header {
             header.add(&0, k, v);
         }
         header
+    }
+    pub fn duplicate_header(&self, doc_id: &str, line_number: usize) -> ftd::p1::Result<()> {
+        let mut hs = std::collections::HashSet::new();
+        for (_, k, _) in self.0.iter().filter(|(_, y, _)| !y.starts_with('/')) {
+            if hs.contains(k) {
+                return Err(ftd::p1::Error::ParseError {
+                    doc_id: doc_id.to_string(),
+                    line_number,
+                    message: format!("`{}` header is repeated", k),
+                });
+            }
+            hs.insert(k);
+        }
+        Ok(())
     }
 
     pub fn add(&mut self, line_number: &usize, name: &str, value: &str) {
@@ -23,10 +35,10 @@ impl Header {
         line_number: usize,
         name: &str,
         def: bool,
-    ) -> Result<bool> {
+    ) -> ftd::p1::Result<bool> {
         match self.bool(doc_id, line_number, name) {
             Ok(b) => Ok(b),
-            Err(Error::NotFound { .. }) => Ok(def),
+            Err(ftd::p1::Error::NotFound { .. }) => Ok(def),
             e => e,
         }
     }
@@ -36,15 +48,15 @@ impl Header {
         doc_id: &str,
         line_number: usize,
         name: &str,
-    ) -> Result<Option<bool>> {
+    ) -> ftd::p1::Result<Option<bool>> {
         match self.bool(doc_id, line_number, name) {
             Ok(b) => Ok(Some(b)),
-            Err(Error::NotFound { .. }) => Ok(None),
+            Err(ftd::p1::Error::NotFound { .. }) => Ok(None),
             Err(e) => Err(e),
         }
     }
 
-    pub fn bool(&self, doc_id: &str, line_number: usize, name: &str) -> Result<bool> {
+    pub fn bool(&self, doc_id: &str, line_number: usize, name: &str) -> ftd::p1::Result<bool> {
         for (l, k, v) in self.0.iter() {
             if k.starts_with('/') {
                 continue;
@@ -61,7 +73,7 @@ impl Header {
                 };
             }
         }
-        Err(Error::NotFound {
+        Err(ftd::p1::Error::NotFound {
             doc_id: doc_id.to_string(),
             line_number,
             key: name.to_string(),
@@ -74,10 +86,10 @@ impl Header {
         line_number: usize,
         name: &str,
         def: i32,
-    ) -> Result<i32> {
+    ) -> ftd::p1::Result<i32> {
         match self.i32(doc_id, line_number, name) {
             Ok(b) => Ok(b),
-            Err(Error::NotFound { .. }) => Ok(def),
+            Err(ftd::p1::Error::NotFound { .. }) => Ok(def),
             e => e,
         }
     }
@@ -87,15 +99,15 @@ impl Header {
         doc_id: &str,
         line_number: usize,
         name: &str,
-    ) -> Result<Option<i32>> {
+    ) -> ftd::p1::Result<Option<i32>> {
         match self.i32(doc_id, line_number, name) {
             Ok(b) => Ok(Some(b)),
-            Err(Error::NotFound { .. }) => Ok(None),
+            Err(ftd::p1::Error::NotFound { .. }) => Ok(None),
             Err(e) => Err(e),
         }
     }
 
-    pub fn i32(&self, doc_id: &str, line_number: usize, name: &str) -> Result<i32> {
+    pub fn i32(&self, doc_id: &str, line_number: usize, name: &str) -> ftd::p1::Result<i32> {
         for (l, k, v) in self.0.iter() {
             if k.starts_with('/') {
                 continue;
@@ -110,14 +122,14 @@ impl Header {
                 });
             }
         }
-        Err(Error::NotFound {
+        Err(ftd::p1::Error::NotFound {
             doc_id: doc_id.to_string(),
             line_number,
             key: name.to_string(),
         })
     }
 
-    pub fn i64(&self, doc_id: &str, line_number: usize, name: &str) -> Result<i64> {
+    pub fn i64(&self, doc_id: &str, line_number: usize, name: &str) -> ftd::p1::Result<i64> {
         for (l, k, v) in self.0.iter() {
             if k.starts_with('/') {
                 continue;
@@ -133,7 +145,7 @@ impl Header {
                 });
             }
         }
-        Err(Error::NotFound {
+        Err(ftd::p1::Error::NotFound {
             doc_id: doc_id.to_string(),
             line_number,
             key: name.to_string(),
@@ -145,15 +157,15 @@ impl Header {
         doc_id: &str,
         line_number: usize,
         name: &str,
-    ) -> Result<Option<i64>> {
+    ) -> ftd::p1::Result<Option<i64>> {
         match self.i64(doc_id, line_number, name) {
             Ok(b) => Ok(Some(b)),
-            Err(Error::NotFound { .. }) => Ok(None),
+            Err(ftd::p1::Error::NotFound { .. }) => Ok(None),
             Err(e) => Err(e),
         }
     }
 
-    pub fn f64(&self, doc_id: &str, line_number: usize, name: &str) -> Result<f64> {
+    pub fn f64(&self, doc_id: &str, line_number: usize, name: &str) -> ftd::p1::Result<f64> {
         for (l, k, v) in self.0.iter() {
             if k.starts_with('/') {
                 continue;
@@ -169,7 +181,7 @@ impl Header {
                 });
             }
         }
-        Err(Error::NotFound {
+        Err(ftd::p1::Error::NotFound {
             doc_id: doc_id.to_string(),
             line_number,
             key: name.to_string(),
@@ -181,10 +193,10 @@ impl Header {
         doc_id: &str,
         line_number: usize,
         name: &str,
-    ) -> Result<Option<f64>> {
+    ) -> ftd::p1::Result<Option<f64>> {
         match self.f64(doc_id, line_number, name) {
             Ok(b) => Ok(Some(b)),
-            Err(Error::NotFound { .. }) => Ok(None),
+            Err(ftd::p1::Error::NotFound { .. }) => Ok(None),
             Err(e) => Err(e),
         }
     }
@@ -195,10 +207,10 @@ impl Header {
         line_number: usize,
         name: &str,
         def: &'a str,
-    ) -> Result<&'a str> {
+    ) -> ftd::p1::Result<&'a str> {
         match self.str(doc_id, line_number, name) {
             Ok(b) => Ok(b),
-            Err(Error::NotFound { .. }) => Ok(def),
+            Err(ftd::p1::Error::NotFound { .. }) => Ok(def),
             e => e,
         }
     }
@@ -238,10 +250,10 @@ impl Header {
         doc_id: &str,
         line_number: usize,
         name: &str,
-    ) -> Result<Option<&str>> {
+    ) -> ftd::p1::Result<Option<&str>> {
         match self.str(doc_id, line_number, name) {
             Ok(b) => Ok(Some(b)),
-            Err(Error::NotFound { .. }) => Ok(None),
+            Err(ftd::p1::Error::NotFound { .. }) => Ok(None),
             Err(e) => Err(e),
         }
     }
@@ -252,7 +264,7 @@ impl Header {
         line_number: usize,
         name: &str,
         arguments: &std::collections::BTreeMap<String, ftd::p2::Kind>,
-    ) -> Result<Vec<(usize, String, Option<&str>)>> {
+    ) -> ftd::p1::Result<Vec<(usize, String, Option<&str>)>> {
         let mut conditional_vector = vec![];
         for (idx, (_, k, v)) in self.0.iter().enumerate() {
             let v = doc.resolve_reference_name(line_number, v, arguments)?;
@@ -269,7 +281,7 @@ impl Header {
             }
         }
         if conditional_vector.is_empty() {
-            Err(Error::NotFound {
+            Err(ftd::p1::Error::NotFound {
                 doc_id: doc.name.to_string(),
                 line_number,
                 key: format!("`{}` header is missing", name),
@@ -279,7 +291,7 @@ impl Header {
         }
     }
 
-    pub fn str(&self, doc_id: &str, line_number: usize, name: &str) -> Result<&str> {
+    pub fn str(&self, doc_id: &str, line_number: usize, name: &str) -> ftd::p1::Result<&str> {
         for (_, k, v) in self.0.iter() {
             if k.starts_with('/') {
                 continue;
@@ -289,14 +301,14 @@ impl Header {
             }
         }
 
-        Err(Error::NotFound {
+        Err(ftd::p1::Error::NotFound {
             doc_id: doc_id.to_string(),
             line_number,
             key: format!("`{}` header is missing", name),
         })
     }
 
-    pub fn string(&self, doc_id: &str, line_number: usize, name: &str) -> Result<String> {
+    pub fn string(&self, doc_id: &str, line_number: usize, name: &str) -> ftd::p1::Result<String> {
         self.str(doc_id, line_number, name).map(ToString::to_string)
     }
 
@@ -305,7 +317,7 @@ impl Header {
         doc_id: &str,
         line_number: usize,
         name: &str,
-    ) -> Result<Option<String>> {
+    ) -> ftd::p1::Result<Option<String>> {
         Ok(self
             .str_optional(doc_id, line_number, name)?
             .map(ToString::to_string))
@@ -317,7 +329,7 @@ impl Header {
         line_number: usize,
         name: &str,
         def: &str,
-    ) -> Result<String> {
+    ) -> ftd::p1::Result<String> {
         self.str_with_default(doc_id, line_number, name, def)
             .map(ToString::to_string)
     }

--- a/src/p2/interpreter.rs
+++ b/src/p2/interpreter.rs
@@ -97,6 +97,9 @@ impl InterpreterState {
                 continue;
             }
 
+            p1.header
+                .duplicate_header(p1.name.as_str(), p1.line_number)?;
+
             // while this is a specific to entire document, we are still creating it in a loop
             // because otherwise the self.interpret() call won't compile.
 
@@ -1544,7 +1547,7 @@ mod test {
                             }),
                         },
                     )])
-                    .collect(),
+                        .collect(),
                     reference: Some(s("foo/bar#name@0")),
                     ..Default::default()
                 },
@@ -2595,7 +2598,7 @@ mod test {
             r"
             -- ftd.color white: white
             dark: white
-            
+
             -- ftd.color 4D4D4D: #4D4D4D
             dark: #4D4D4D
 
@@ -4640,7 +4643,7 @@ mod test {
 
         p!(
             "
-            -- ftd.image-src src0: 
+            -- ftd.image-src src0:
             light: /static/home/document-type-min.png
             dark: /static/home/document-type-min.png
 
@@ -4956,14 +4959,14 @@ mod test {
 
         p!(
             "
-            -- ftd.image-src src0: 
+            -- ftd.image-src src0:
             light: /static/home/document-type-min.png
             dark: /static/home/document-type-min.png
 
-            -- ftd.image-src src1: 
+            -- ftd.image-src src1:
             light: second-image.png
             dark: second-image.png
-            
+
             -- ftd.column white-two-image:
             caption title:
             optional body about:
@@ -5378,11 +5381,11 @@ mod test {
         );
         p!(
             "
-            -- ftd.image-src src0: 
+            -- ftd.image-src src0:
             light: /static/home/document-type-min.png
             dark: /static/home/document-type-min.png
 
-            -- ftd.image-src src1: 
+            -- ftd.image-src src1:
             light: second-image.png
             dark: second-image.png
 
@@ -5936,11 +5939,11 @@ mod test {
 
         p!(
             "
-            -- ftd.image-src src0: 
+            -- ftd.image-src src0:
             light: foo.png
             dark: foo.png
 
-            -- ftd.image-src src1: 
+            -- ftd.image-src src1:
             light: bar.png
             dark: bar.png
 
@@ -10578,18 +10581,18 @@ mod test {
                 -- ftd.row foo:
                 caption name:
                 string body:
-    
+
                 --- ftd.text: $name
-    
+
                 --- ftd.text: $body
-    
+
                 -- record data:
                 string title:
                 string description:
-    
+
                 -- data list test:
                 $processor$: read_package_records_from_cargo_toml
-    
+
                 -- foo: $obj.title
                 $loop$: $test as $obj
                 body: $obj.description
@@ -10876,7 +10879,7 @@ mod test {
                                                                 },
                                                             ),
                                                         ])
-                                                        .collect(),
+                                                            .collect(),
                                                     }},
                                                     ftd::PropertyValue::Value {value: ftd::Value::Record {
                                                         name: s("foo/bar#toc-record"),
@@ -10912,7 +10915,7 @@ mod test {
                                                                 },
                                                             ),
                                                         ])
-                                                        .collect(),
+                                                            .collect(),
                                                     }},
                                                 ],
                                                 kind: ftd::p2::Kind::Record {
@@ -10941,7 +10944,7 @@ mod test {
                                         },
                                     ),
                                 ])
-                                .collect(),
+                                    .collect(),
                             },
                         }],
                         kind: ftd::p2::Kind::Record {
@@ -13182,10 +13185,10 @@ mod test {
                 r"
                 -- ftd.color red: red
                 dark: red
-                
+
                 -- ftd.color green: green
                 dark: green
-                
+
                 /-- ftd.text:
                 cursor: pointer
 
@@ -13745,11 +13748,11 @@ mod test {
                 "
                 -- integer count: 0
 
-                -- ftd.image-src src0: 
+                -- ftd.image-src src0:
                 light: https://www.liveabout.com/thmb/YCJmu1khSJo8kMYM090QCd9W78U=/1250x0/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/powerpuff_girls-56a00bc45f9b58eba4aea61d.jpg
                 dark: https://www.liveabout.com/thmb/YCJmu1khSJo8kMYM090QCd9W78U=/1250x0/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/powerpuff_girls-56a00bc45f9b58eba4aea61d.jpg
 
-                -- ftd.image-src src1: 
+                -- ftd.image-src src1:
                 light: https://upload.wikimedia.org/wikipedia/en/d/d4/Mickey_Mouse.png
                 dark: https://upload.wikimedia.org/wikipedia/en/d/d4/Mickey_Mouse.png
 
@@ -13771,7 +13774,7 @@ mod test {
             ),
             &ftd::p2::TestLibrary {},
         )
-        .expect("found error");
+            .expect("found error");
 
         pretty_assertions::assert_eq!(g_col, main);
     }
@@ -15117,7 +15120,7 @@ mod test {
             "foo/bar",
             indoc::indoc!(
                 "
-                -- ftd.image-src src0: 
+                -- ftd.image-src src0:
                 light: https://www.nilinswap.com/static/img/dp.jpeg
                 dark: https://www.nilinswap.com/static/img/dp.jpeg
 
@@ -15176,7 +15179,7 @@ mod test {
                             default: None,
                         },
                     )])
-                    .collect(),
+                        .collect(),
                     events: vec![
                         ftd::Event {
                             name: s("onmouseenter"),
@@ -15196,7 +15199,7 @@ mod test {
                                         },
                                     ],
                                 )])
-                                .collect(),
+                                    .collect(),
                             },
                         },
                         ftd::Event {
@@ -15217,7 +15220,7 @@ mod test {
                                         },
                                     ],
                                 )])
-                                .collect(),
+                                    .collect(),
                             },
                         },
                     ],
@@ -15394,7 +15397,7 @@ mod test {
                                 default: None,
                             },
                         )])
-                        .collect(),
+                            .collect(),
                         reference: Some(s("foo/bar#a@0")),
                         ..Default::default()
                     },
@@ -15424,7 +15427,7 @@ mod test {
                                     reference: None,
                                 }],
                             )])
-                            .collect(),
+                                .collect(),
                         },
                     },
                 ],
@@ -15559,7 +15562,7 @@ mod test {
                                         default: None,
                                     },
                                 )])
-                                .collect(),
+                                    .collect(),
                                 reference: Some(s("foo/bar#a@0")),
                                 ..Default::default()
                             },
@@ -15613,7 +15616,7 @@ mod test {
                                         },
                                     ],
                                 )])
-                                .collect(),
+                                    .collect(),
                             },
                         },
                     ],
@@ -15646,7 +15649,7 @@ mod test {
                                 default: None,
                             },
                         )])
-                        .collect(),
+                            .collect(),
                         ..Default::default()
                     },
                     ..Default::default()
@@ -15737,7 +15740,7 @@ mod test {
                             default: None,
                         },
                     )])
-                    .collect(),
+                        .collect(),
                     reference: Some(s("foo/bar#bar")),
                     color: Some(ftd::Color {
                         light: ftd::ColorValue {
@@ -16009,12 +16012,12 @@ mod test {
                 color: $red
                 line-clamp: $line-clamp
 
-                -- ftd.column moo: 
+                -- ftd.column moo:
                 caption msg: world
                 string other-msg: world again
                 ftd.ui t:
                 ftd.ui k:
-                
+
                 --- ftd.text: $msg
 
                 --- ftd.text: $other-msg
@@ -16121,7 +16124,7 @@ mod test {
                 -- optional string active:
 
                 -- active: hello
-                
+
                 -- ftd.text: $active
                 if: $active is not null
 
@@ -16129,7 +16132,7 @@ mod test {
                 if: $active is null
 
                 -- optional string flags:
-                
+
                 -- ftd.text: $flags
                 if: $flags is not null
 
@@ -16262,7 +16265,7 @@ mod test {
 
             -- ftd.column foo:
             object o:
-        
+
             --- ftd.text: Data
 
             -- foo:
@@ -16330,51 +16333,51 @@ mod test {
         main.container
             .children
             .push(ftd::Element::Input(ftd::Input {
-                common: ftd::Common {
-                    events: vec![
-                        ftd::Event {
-                            name: s("onchange"),
-                            action: ftd::Action {
-                                action: s("set-value"),
-                                target: s("foo/bar#input-data"),
-                                parameters: std::array::IntoIter::new([(
-                                    s("value"),
-                                    vec![
-                                        ftd::event::ParameterData {
-                                            value: s("$VALUE"),
-                                            reference: None,
-                                        },
-                                        ftd::event::ParameterData {
-                                            value: s("string"),
-                                            reference: None,
-                                        },
-                                    ],
-                                )])
-                                .collect(),
-                            },
+            common: ftd::Common {
+                events: vec![
+                    ftd::Event {
+                        name: s("onchange"),
+                        action: ftd::Action {
+                            action: s("set-value"),
+                            target: s("foo/bar#input-data"),
+                            parameters: std::array::IntoIter::new([(
+                                s("value"),
+                                vec![
+                                    ftd::event::ParameterData {
+                                        value: s("$VALUE"),
+                                        reference: None,
+                                    },
+                                    ftd::event::ParameterData {
+                                        value: s("string"),
+                                        reference: None,
+                                    },
+                                ],
+                            )])
+                            .collect(),
                         },
-                        ftd::Event {
-                            name: s("onchange"),
-                            action: ftd::Action {
-                                action: s("message-host"),
-                                target: s("$obj"),
-                                parameters: std::array::IntoIter::new([(
-                                    "data".to_string(),
-                                    vec![ftd::event::ParameterData {
+                    },
+                    ftd::Event {
+                        name: s("onchange"),
+                        action: ftd::Action {
+                            action: s("message-host"),
+                            target: s("$obj"),
+                            parameters: std::array::IntoIter::new([(
+                                "data".to_string(),
+                                vec![ftd::event::ParameterData {
                                     value: s(
                                         "{\"function\":\"some-function\",\"value\":\"Nothing\"}",
                                     ),
                                     reference: Some(s("{\"value\":\"foo/bar#input-data\"}")),
                                 }],
-                                )])
-                                .collect(),
-                            },
+                            )])
+                            .collect(),
                         },
-                    ],
-                    ..Default::default()
-                },
-                placeholder: None,
-            }));
+                    },
+                ],
+                ..Default::default()
+            },
+            placeholder: None,
+        }));
 
         p!(
             "
@@ -17400,14 +17403,14 @@ mod test {
             integer w:
             color: $green
             border-width: $w
-            
+
             --- ftd.text: $title
 
             --- ftd.text: $subtitle
 
             --- ftd.text: $bio
-            
-            --- ftd.boolean: $active 
+
+            --- ftd.boolean: $active
             ",
             (bag, main),
         );
@@ -17456,7 +17459,7 @@ mod test {
             -- optional string bar:
 
             -- bar: Something
-            
+
             -- ftd.text: $bar
             if: $bar == Something
             ",

--- a/src/p2/interpreter.rs
+++ b/src/p2/interpreter.rs
@@ -97,8 +97,7 @@ impl InterpreterState {
                 continue;
             }
 
-            p1.header
-                .duplicate_header(p1.name.as_str(), p1.line_number)?;
+            p1.header.duplicate_header()?;
 
             // while this is a specific to entire document, we are still creating it in a loop
             // because otherwise the self.interpret() call won't compile.

--- a/src/p2/interpreter.rs
+++ b/src/p2/interpreter.rs
@@ -16333,51 +16333,51 @@ mod test {
         main.container
             .children
             .push(ftd::Element::Input(ftd::Input {
-            common: ftd::Common {
-                events: vec![
-                    ftd::Event {
-                        name: s("onchange"),
-                        action: ftd::Action {
-                            action: s("set-value"),
-                            target: s("foo/bar#input-data"),
-                            parameters: std::array::IntoIter::new([(
-                                s("value"),
-                                vec![
-                                    ftd::event::ParameterData {
-                                        value: s("$VALUE"),
-                                        reference: None,
-                                    },
-                                    ftd::event::ParameterData {
-                                        value: s("string"),
-                                        reference: None,
-                                    },
-                                ],
-                            )])
-                            .collect(),
+                common: ftd::Common {
+                    events: vec![
+                        ftd::Event {
+                            name: s("onchange"),
+                            action: ftd::Action {
+                                action: s("set-value"),
+                                target: s("foo/bar#input-data"),
+                                parameters: std::array::IntoIter::new([(
+                                    s("value"),
+                                    vec![
+                                        ftd::event::ParameterData {
+                                            value: s("$VALUE"),
+                                            reference: None,
+                                        },
+                                        ftd::event::ParameterData {
+                                            value: s("string"),
+                                            reference: None,
+                                        },
+                                    ],
+                                )])
+                                .collect(),
+                            },
                         },
-                    },
-                    ftd::Event {
-                        name: s("onchange"),
-                        action: ftd::Action {
-                            action: s("message-host"),
-                            target: s("$obj"),
-                            parameters: std::array::IntoIter::new([(
-                                "data".to_string(),
-                                vec![ftd::event::ParameterData {
+                        ftd::Event {
+                            name: s("onchange"),
+                            action: ftd::Action {
+                                action: s("message-host"),
+                                target: s("$obj"),
+                                parameters: std::array::IntoIter::new([(
+                                    "data".to_string(),
+                                    vec![ftd::event::ParameterData {
                                     value: s(
                                         "{\"function\":\"some-function\",\"value\":\"Nothing\"}",
                                     ),
                                     reference: Some(s("{\"value\":\"foo/bar#input-data\"}")),
                                 }],
-                            )])
-                            .collect(),
+                                )])
+                                .collect(),
+                            },
                         },
-                    },
-                ],
-                ..Default::default()
-            },
-            placeholder: None,
-        }));
+                    ],
+                    ..Default::default()
+                },
+                placeholder: None,
+            }));
 
         p!(
             "

--- a/src/p2/interpreter.rs
+++ b/src/p2/interpreter.rs
@@ -1546,7 +1546,7 @@ mod test {
                             }),
                         },
                     )])
-                        .collect(),
+                    .collect(),
                     reference: Some(s("foo/bar#name@0")),
                     ..Default::default()
                 },
@@ -2597,7 +2597,7 @@ mod test {
             r"
             -- ftd.color white: white
             dark: white
-
+            
             -- ftd.color 4D4D4D: #4D4D4D
             dark: #4D4D4D
 
@@ -4642,7 +4642,7 @@ mod test {
 
         p!(
             "
-            -- ftd.image-src src0:
+            -- ftd.image-src src0: 
             light: /static/home/document-type-min.png
             dark: /static/home/document-type-min.png
 
@@ -4958,14 +4958,14 @@ mod test {
 
         p!(
             "
-            -- ftd.image-src src0:
+            -- ftd.image-src src0: 
             light: /static/home/document-type-min.png
             dark: /static/home/document-type-min.png
 
-            -- ftd.image-src src1:
+            -- ftd.image-src src1: 
             light: second-image.png
             dark: second-image.png
-
+            
             -- ftd.column white-two-image:
             caption title:
             optional body about:
@@ -5380,11 +5380,11 @@ mod test {
         );
         p!(
             "
-            -- ftd.image-src src0:
+            -- ftd.image-src src0: 
             light: /static/home/document-type-min.png
             dark: /static/home/document-type-min.png
 
-            -- ftd.image-src src1:
+            -- ftd.image-src src1: 
             light: second-image.png
             dark: second-image.png
 
@@ -5938,11 +5938,11 @@ mod test {
 
         p!(
             "
-            -- ftd.image-src src0:
+            -- ftd.image-src src0: 
             light: foo.png
             dark: foo.png
 
-            -- ftd.image-src src1:
+            -- ftd.image-src src1: 
             light: bar.png
             dark: bar.png
 
@@ -10580,18 +10580,18 @@ mod test {
                 -- ftd.row foo:
                 caption name:
                 string body:
-
+    
                 --- ftd.text: $name
-
+    
                 --- ftd.text: $body
-
+    
                 -- record data:
                 string title:
                 string description:
-
+    
                 -- data list test:
                 $processor$: read_package_records_from_cargo_toml
-
+    
                 -- foo: $obj.title
                 $loop$: $test as $obj
                 body: $obj.description
@@ -10878,7 +10878,7 @@ mod test {
                                                                 },
                                                             ),
                                                         ])
-                                                            .collect(),
+                                                        .collect(),
                                                     }},
                                                     ftd::PropertyValue::Value {value: ftd::Value::Record {
                                                         name: s("foo/bar#toc-record"),
@@ -10914,7 +10914,7 @@ mod test {
                                                                 },
                                                             ),
                                                         ])
-                                                            .collect(),
+                                                        .collect(),
                                                     }},
                                                 ],
                                                 kind: ftd::p2::Kind::Record {
@@ -10943,7 +10943,7 @@ mod test {
                                         },
                                     ),
                                 ])
-                                    .collect(),
+                                .collect(),
                             },
                         }],
                         kind: ftd::p2::Kind::Record {
@@ -13184,10 +13184,10 @@ mod test {
                 r"
                 -- ftd.color red: red
                 dark: red
-
+                
                 -- ftd.color green: green
                 dark: green
-
+                
                 /-- ftd.text:
                 cursor: pointer
 
@@ -13747,11 +13747,11 @@ mod test {
                 "
                 -- integer count: 0
 
-                -- ftd.image-src src0:
+                -- ftd.image-src src0: 
                 light: https://www.liveabout.com/thmb/YCJmu1khSJo8kMYM090QCd9W78U=/1250x0/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/powerpuff_girls-56a00bc45f9b58eba4aea61d.jpg
                 dark: https://www.liveabout.com/thmb/YCJmu1khSJo8kMYM090QCd9W78U=/1250x0/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/powerpuff_girls-56a00bc45f9b58eba4aea61d.jpg
 
-                -- ftd.image-src src1:
+                -- ftd.image-src src1: 
                 light: https://upload.wikimedia.org/wikipedia/en/d/d4/Mickey_Mouse.png
                 dark: https://upload.wikimedia.org/wikipedia/en/d/d4/Mickey_Mouse.png
 
@@ -13773,7 +13773,7 @@ mod test {
             ),
             &ftd::p2::TestLibrary {},
         )
-            .expect("found error");
+        .expect("found error");
 
         pretty_assertions::assert_eq!(g_col, main);
     }
@@ -15119,7 +15119,7 @@ mod test {
             "foo/bar",
             indoc::indoc!(
                 "
-                -- ftd.image-src src0:
+                -- ftd.image-src src0: 
                 light: https://www.nilinswap.com/static/img/dp.jpeg
                 dark: https://www.nilinswap.com/static/img/dp.jpeg
 
@@ -15178,7 +15178,7 @@ mod test {
                             default: None,
                         },
                     )])
-                        .collect(),
+                    .collect(),
                     events: vec![
                         ftd::Event {
                             name: s("onmouseenter"),
@@ -15198,7 +15198,7 @@ mod test {
                                         },
                                     ],
                                 )])
-                                    .collect(),
+                                .collect(),
                             },
                         },
                         ftd::Event {
@@ -15219,7 +15219,7 @@ mod test {
                                         },
                                     ],
                                 )])
-                                    .collect(),
+                                .collect(),
                             },
                         },
                     ],
@@ -15396,7 +15396,7 @@ mod test {
                                 default: None,
                             },
                         )])
-                            .collect(),
+                        .collect(),
                         reference: Some(s("foo/bar#a@0")),
                         ..Default::default()
                     },
@@ -15426,7 +15426,7 @@ mod test {
                                     reference: None,
                                 }],
                             )])
-                                .collect(),
+                            .collect(),
                         },
                     },
                 ],
@@ -15561,7 +15561,7 @@ mod test {
                                         default: None,
                                     },
                                 )])
-                                    .collect(),
+                                .collect(),
                                 reference: Some(s("foo/bar#a@0")),
                                 ..Default::default()
                             },
@@ -15615,7 +15615,7 @@ mod test {
                                         },
                                     ],
                                 )])
-                                    .collect(),
+                                .collect(),
                             },
                         },
                     ],
@@ -15648,7 +15648,7 @@ mod test {
                                 default: None,
                             },
                         )])
-                            .collect(),
+                        .collect(),
                         ..Default::default()
                     },
                     ..Default::default()
@@ -15739,7 +15739,7 @@ mod test {
                             default: None,
                         },
                     )])
-                        .collect(),
+                    .collect(),
                     reference: Some(s("foo/bar#bar")),
                     color: Some(ftd::Color {
                         light: ftd::ColorValue {
@@ -16011,12 +16011,12 @@ mod test {
                 color: $red
                 line-clamp: $line-clamp
 
-                -- ftd.column moo:
+                -- ftd.column moo: 
                 caption msg: world
                 string other-msg: world again
                 ftd.ui t:
                 ftd.ui k:
-
+                
                 --- ftd.text: $msg
 
                 --- ftd.text: $other-msg
@@ -16123,7 +16123,7 @@ mod test {
                 -- optional string active:
 
                 -- active: hello
-
+                
                 -- ftd.text: $active
                 if: $active is not null
 
@@ -16131,7 +16131,7 @@ mod test {
                 if: $active is null
 
                 -- optional string flags:
-
+                
                 -- ftd.text: $flags
                 if: $flags is not null
 
@@ -16264,7 +16264,7 @@ mod test {
 
             -- ftd.column foo:
             object o:
-
+        
             --- ftd.text: Data
 
             -- foo:
@@ -17402,14 +17402,14 @@ mod test {
             integer w:
             color: $green
             border-width: $w
-
+            
             --- ftd.text: $title
 
             --- ftd.text: $subtitle
 
             --- ftd.text: $bio
-
-            --- ftd.boolean: $active
+            
+            --- ftd.boolean: $active 
             ",
             (bag, main),
         );
@@ -17458,7 +17458,7 @@ mod test {
             -- optional string bar:
 
             -- bar: Something
-
+            
             -- ftd.text: $bar
             if: $bar == Something
             ",

--- a/src/p2/interpreter.rs
+++ b/src/p2/interpreter.rs
@@ -3,7 +3,7 @@ pub struct InterpreterState {
     pub id: String,
     pub bag: std::collections::BTreeMap<String, ftd::p2::Thing>,
     pub document_stack: Vec<ParsedDocument>,
-    pub parsed_libs: Vec<String>,
+    pub parsed_libs: std::collections::BTreeMap<String, Vec<String>>,
 }
 
 impl InterpreterState {
@@ -29,12 +29,12 @@ impl InterpreterState {
     }
 
     fn library_in_the_bag(&self, name: &str) -> bool {
-        self.parsed_libs.contains(&name.to_string())
+        self.parsed_libs.contains_key(name)
     }
 
     fn add_library_to_bag(&mut self, name: &str) {
         if !self.library_in_the_bag(name) {
-            self.parsed_libs.push(name.to_string());
+            self.parsed_libs.insert(name.to_string(), vec![]);
         }
     }
 
@@ -59,6 +59,11 @@ impl InterpreterState {
                             module,
                         });
                     }
+                    if let Some(foreign_var_prefix) = self.parsed_libs.get(module.as_str()) {
+                        self.document_stack[l]
+                            .foreign_variable_prefix
+                            .extend_from_slice(foreign_var_prefix.as_slice());
+                    }
                 } else {
                     break;
                 }
@@ -67,7 +72,6 @@ impl InterpreterState {
             self.document_stack[l].reorder(&self.bag)?;
         }
         let parsed_document = &mut self.document_stack[l];
-        let mut instructions: Vec<ftd::Instruction> = Default::default();
 
         while let Some(p1) = parsed_document.sections.last_mut() {
             // first resolve the foreign_variables in the section before proceeding further
@@ -97,8 +101,6 @@ impl InterpreterState {
                 continue;
             }
 
-            p1.header.duplicate_header()?;
-
             // while this is a specific to entire document, we are still creating it in a loop
             // because otherwise the self.interpret() call won't compile.
 
@@ -112,6 +114,7 @@ impl InterpreterState {
             let mut thing = vec![];
 
             if p1.name.starts_with("record ") {
+                p1.header.duplicate_header()?;
                 // declare a record
                 let d =
                     ftd::p2::Record::from_p1(p1.name.as_str(), &p1.header, &doc, p1.line_number)?;
@@ -152,18 +155,21 @@ impl InterpreterState {
                 //         Not sure if its a good idea tho.
                 // }
             } else if p1.name == "container" {
-                instructions.push(ftd::Instruction::ChangeContainer {
-                    name: doc.resolve_name_with_instruction(
-                        p1.line_number,
-                        p1.caption(p1.line_number, doc.name)?.as_str(),
-                        &instructions,
-                    )?,
-                });
+                parsed_document
+                    .instructions
+                    .push(ftd::Instruction::ChangeContainer {
+                        name: doc.resolve_name_with_instruction(
+                            p1.line_number,
+                            p1.caption(p1.line_number, doc.name)?.as_str(),
+                            &parsed_document.instructions,
+                        )?,
+                    });
             } else if let Ok(ftd::variable::VariableData {
                 type_: ftd::variable::Type::Component,
                 ..
             }) = var_data
             {
+                p1.header.duplicate_header()?;
                 // declare a function
                 let d = ftd::Component::from_p1(&p1, &doc)?;
                 let name = doc.resolve_name(p1.line_number, &d.full_name.to_string())?;
@@ -188,6 +194,7 @@ impl InterpreterState {
                         section: p1,
                     });
                 } else if var_data.is_none() || var_data.is_optional() {
+                    p1.var_dup_header_check(self.id.as_str(), &self.bag, var_data)?;
                     // declare and instantiate a variable
                     ftd::Variable::from_p1(&p1, &doc)?
                 } else {
@@ -264,6 +271,7 @@ impl InterpreterState {
                     ftd::p2::Thing::Variable(doc.set_value(p1.line_number, p1.name.as_str(), v)?),
                 ));
             } else {
+                p1.header.duplicate_header()?;
                 // cloning because https://github.com/rust-lang/rust/issues/59159
                 match (doc.get_thing(p1.line_number, p1.name.as_str())?).clone() {
                     ftd::p2::Thing::Variable(_) => {
@@ -294,15 +302,17 @@ impl InterpreterState {
                                 is_commented: p1.is_commented,
                                 line_number: p1.line_number,
                             };
-                            instructions.push(ftd::Instruction::RecursiveChildComponent {
-                                child: ftd::component::recursive_child_component(
-                                    loop_data,
-                                    &section_to_subsection,
-                                    &doc,
-                                    &Default::default(),
-                                    None,
-                                )?,
-                            });
+                            parsed_document.instructions.push(
+                                ftd::Instruction::RecursiveChildComponent {
+                                    child: ftd::component::recursive_child_component(
+                                        loop_data,
+                                        &section_to_subsection,
+                                        &doc,
+                                        &Default::default(),
+                                        None,
+                                    )?,
+                                },
+                            );
                         } else {
                             let parent = ftd::ChildComponent::from_p1(
                                 p1.line_number,
@@ -357,7 +367,9 @@ impl InterpreterState {
                                 }
                             }
 
-                            instructions.push(ftd::Instruction::Component { children, parent })
+                            parsed_document
+                                .instructions
+                                .push(ftd::Instruction::Component { children, parent })
                         }
                     }
                     ftd::p2::Thing::Record(mut r) => {
@@ -396,7 +408,7 @@ impl InterpreterState {
             &self.id,
             self.document_stack[0].get_doc_aliases(),
             self.bag,
-            instructions,
+            self.document_stack[0].instructions.clone(),
         );
 
         let main = if cfg!(test) {
@@ -419,6 +431,10 @@ impl InterpreterState {
         // d.data.extend(rt.bag);
 
         Ok(Interpreter::Done { document: d })
+    }
+
+    fn resolve_foreign_variable_name(name: &str) -> String {
+        name.replace('.', "-")
     }
 
     fn resolve_foreign_variable(
@@ -497,9 +513,11 @@ impl InterpreterState {
                 return Ok(None);
             }
             if let Some(val) = value.clone().strip_prefix('$') {
-                if is_foreign_variable(val, foreign_variables, doc.aliases)? {
+                if is_foreign_variable(val, foreign_variables, doc, line_number)? {
                     let val = doc.resolve_name(line_number, val)?;
-                    *value = format!("${}", val.as_str());
+                    *value = ftd::InterpreterState::resolve_foreign_variable_name(
+                        format!("${}", val.as_str()).as_str(),
+                    );
                     return Ok(Some(val));
                 }
             }
@@ -509,17 +527,12 @@ impl InterpreterState {
         fn is_foreign_variable(
             variable: &str,
             foreign_variables: &[String],
-            doc_aliases: &std::collections::BTreeMap<String, String>,
+            doc: &ftd::p2::TDoc,
+            line_number: usize,
         ) -> ftd::p1::Result<bool> {
-            let var_name = {
-                let mut var_name = ftd::p2::utils::get_doc_name_and_remaining(variable)?.0;
-                if let Some(val) = doc_aliases.get(var_name.as_str()) {
-                    var_name = val.to_string();
-                }
-                var_name
-            };
+            let var_name = doc.resolve_name(line_number, variable)?;
 
-            if foreign_variables.contains(&var_name) {
+            if foreign_variables.iter().any(|v| var_name.starts_with(v)) {
                 return Ok(true);
             }
             Ok(false)
@@ -558,10 +571,13 @@ impl InterpreterState {
         Ok(None)
     }
 
-    pub fn add_foreign_variable_prefix(&mut self, prefix: &str) {
+    pub fn add_foreign_variable_prefix(&mut self, module: &str, prefix: Vec<String>) {
         if let Some(document) = self.document_stack.last_mut() {
-            document.foreign_variable_prefix.push(prefix.to_string());
+            document
+                .foreign_variable_prefix
+                .extend_from_slice(prefix.as_slice());
         }
+        self.parsed_libs.insert(module.to_string(), prefix);
     }
 
     pub fn continue_after_import(mut self, id: &str, source: &str) -> ftd::p1::Result<Interpreter> {
@@ -583,7 +599,9 @@ impl InterpreterState {
             bag: &self.bag,
             local_variables: &mut Default::default(),
         };
-        let var_name = doc.resolve_name(0, variable)?;
+        let var_name = ftd::InterpreterState::resolve_foreign_variable_name(
+            doc.resolve_name(0, variable)?.as_str(),
+        );
         self.bag.insert(
             var_name.clone(),
             ftd::p2::Thing::Variable(ftd::Variable {
@@ -707,6 +725,7 @@ pub struct ParsedDocument {
     doc_aliases: std::collections::BTreeMap<String, String>,
     var_types: Vec<String>,
     foreign_variable_prefix: Vec<String>,
+    instructions: Vec<ftd::Instruction>,
 }
 
 impl ParsedDocument {
@@ -718,6 +737,7 @@ impl ParsedDocument {
             doc_aliases: ftd::p2::interpreter::default_aliases(),
             var_types: Default::default(),
             foreign_variable_prefix: vec![],
+            instructions: vec![],
         })
     }
 


### PR DESCRIPTION
1. Called the function duplicate_headers() from "header.rs" in specific places in "interpreter.rs".
2. Added a new function var_dup_header_check() in "section.rs" and called for "var_data" in "interpreter.rs"
3. This is now working for sections as well as lists.