### PR TITLE
Commented sections were getting initialized 

### DIFF
--- a/src/p2/utils.rs
+++ b/src/p2/utils.rs
@@ -1232,6 +1232,9 @@ pub fn reorder(
     let mut list_or_var = vec![];
     let mut var_types = vec![];
     for (idx, p1) in p1.iter().enumerate() {
+        if p1.is_commented {
+            continue;
+        }
         let var_data =
             ftd::variable::VariableData::get_name_kind(&p1.name, doc, p1.line_number, &var_types);
         if p1.name == "import"


### PR DESCRIPTION
- Commented sections were getting processed inside interpreter
- Ignored those commented sections which was getting processed while reordering the document. 
- Refer this issue - https://github.com/FifthTry/ftd/issues/239