### PR TITLE
Caption body checks added 

### DIFF
--- a/src/component.rs
+++ b/src/component.rs
@@ -2354,11 +2354,12 @@ pub fn takes_caption(
 
         if let ftd::p2::Kind::String { caption, body, .. } = inner_kind {
             if *caption {
-                return if (*body && !has_body) || (!*body) {
+                // (*body && !has_body) || (!*body)
+                return if !*body || !has_body {
                     Ok(true)
                 } else {
                     return Err(ftd::p1::Error::ParseError {
-                        message: format!("pass either caption or body"),
+                        message: "pass either caption or body".to_string(),
                         doc_id: doc.name.to_string(),
                         line_number: line_number.unwrap(),
                     });
@@ -2366,7 +2367,7 @@ pub fn takes_caption(
             }
         }
     }
-    return Ok(false);
+    Ok(false)
 }
 
 pub fn takes_body(
@@ -2385,11 +2386,11 @@ pub fn takes_body(
 
         if let ftd::p2::Kind::String { caption, body, .. } = inner_kind {
             if *body {
-                return if (*caption && !has_caption) || (!*caption) {
+                return if !has_caption || !*caption {
                     Ok(true)
                 } else {
                     return Err(ftd::p1::Error::ParseError {
-                        message: format!("pass either caption or body"),
+                        message: "pass either caption or body".to_string(),
                         doc_id: doc.name.to_string(),
                         line_number,
                     });
@@ -2397,7 +2398,7 @@ pub fn takes_body(
             }
         }
     }
-    return Ok(false);
+    Ok(false)
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -2440,9 +2441,9 @@ pub fn check_caption_body(
 
         for (ln, key, val) in header_list.iter() {
             if key.contains("if")
-                || (key.starts_with("$") && key.ends_with("$"))
-                || key.starts_with("/")
-                || key.starts_with(">")
+                || (key.starts_with('$') && key.ends_with('$'))
+                || key.starts_with('/')
+                || key.starts_with('>')
             {
                 continue;
             }
@@ -2585,7 +2586,7 @@ pub fn check_caption_body(
                 && !takes_body(arguments, has_caption, doc, line_number)?
             {
                 return Err(ftd::p1::Error::ParseError {
-                    message: format!("body passed with no header accepting it !!"),
+                    message: "body passed with no header accepting it !!".to_string(),
                     doc_id: doc.name.to_string(),
                     line_number: body_ln.unwrap() as usize,
                 });

--- a/src/component.rs
+++ b/src/component.rs
@@ -2419,9 +2419,6 @@ pub fn check_caption_body(
     let has_caption: bool = caption.is_some();
     let has_body: bool = body.is_some();
 
-    // println!("has caption = {}", has_caption);
-    // println!("has body = {}", has_body);
-
     match body {
         Some(b) => body_ln = Some(b.0),
         None => {}
@@ -2435,10 +2432,6 @@ pub fn check_caption_body(
         all_arguments.extend(c.arguments.clone());
         all_arguments.extend(root_arguments.clone());
 
-        // println!("arguments = {:?}", arguments.keys());
-        // println!("root arg = {:?}", root_arguments.keys());
-        // println!("comp arg = {:?}", c.arguments.keys());
-
         for (ln, key, val) in header_list.iter() {
             if key.contains("if")
                 || (key.starts_with('$') && key.ends_with('$'))
@@ -2451,8 +2444,6 @@ pub fn check_caption_body(
             let has_value = !val.is_empty();
             let key_tokens: Vec<&str> = key.rsplit(' ').collect();
             let identifier = key_tokens[0];
-
-            // println!("key = {}, identifier = {},  val = {}", key, identifier, val);
 
             let kind = &all_arguments[identifier];
 
@@ -2564,9 +2555,6 @@ pub fn check_caption_body(
             }
         }
 
-        // println!("caption pass = {}", caption_pass);
-        // println!("body pass = {}", body_pass);
-
         if !(caption_pass && body_pass) {
             if has_caption
                 && !caption_pass
@@ -2621,18 +2609,9 @@ pub fn read_properties(
         root_arguments
     };
 
-    // println!("root = {}", root);
-    // println!("caption = {:?}", caption);
-    // println!("body = {:?}", body);
-    // println!("fn name = {}", fn_name);
-
-    // println!("arguments = {:?}", arguments.keys());
-    // println!("root arg = {:?}", &root_arguments.keys());
-
     if doc.bag.contains_key(root) && root.ends_with(fn_name) {
         let thing = &doc.bag[root];
 
-        // println!("Checking root = {}", root);
         check_caption_body(
             thing,
             doc,
@@ -2644,6 +2623,7 @@ pub fn read_properties(
             line_number,
         )?;
     }
+
     for (name, kind) in root_arguments.iter() {
         if let Some(prop) = root_properties.get(name) {
             properties.insert(name.to_string(), prop.clone());


### PR DESCRIPTION
- matching caption and/or body name in declaration and invocation/calling
- checks are done on invocation of variable components
- working for section and subsections as well
- refer issue - https://github.com/FifthTry/ftd/issues/217