### PR TITLE
Allow font weight specification in style

### DIFF
--- a/src/html.rs
+++ b/src/html.rs
@@ -897,6 +897,11 @@ impl ftd::Text {
                 .insert(s("-webkit-box-orient"), "vertical".to_string());
         }
 
+        if let Some(ref weight) = self.style.weight {
+            let (key, value) = style(weight);
+            n.style.insert(s(key.as_str()), value);
+        }
+
         // TODO: text styles
         n
     }
@@ -952,6 +957,12 @@ impl ftd::TextBlock {
             let (key, value) = length(indent, "text-indent");
             n.style.insert(s(key.as_str()), value);
         }
+
+        if let Some(ref weight) = self.style.weight {
+            let (key, value) = style(weight);
+            n.style.insert(s(key.as_str()), value);
+        }
+
         n
     }
 }
@@ -992,6 +1003,11 @@ impl ftd::Code {
 
         if let Some(p) = &self.text_indent {
             let (key, value) = length(p, "text-indent");
+            n.style.insert(s(key.as_str()), value);
+        }
+
+        if let Some(ref weight) = self.style.weight {
+            let (key, value) = style(weight);
             n.style.insert(s(key.as_str()), value);
         }
 
@@ -1105,6 +1121,12 @@ impl ftd::Markups {
         if self.children.is_empty() {
             n.text = Some(self.text.rendered.clone());
         }
+
+        if let Some(ref weight) = self.style.weight {
+            let (key, value) = style(weight);
+            n.style.insert(s(key.as_str()), value);
+        }
+
         n.children = self
             .children
             .iter()
@@ -2011,5 +2033,19 @@ pub fn spacing(l: &ftd::Spacing, f: &str) -> (String, String) {
         ftd::Spacing::SpaceBetween => (s("justify-content"), s("space-between")),
         ftd::Spacing::SpaceAround => (s("justify-content"), s("space-around")),
         ftd::Spacing::Absolute { value } => (s(f), s(value)),
+    }
+}
+
+fn style(l: &ftd::Weight) -> (String, String) {
+    match l {
+        ftd::Weight::Heavy => ("font-weight".to_string(), "900".to_string()),
+        ftd::Weight::ExtraBold => ("font-weight".to_string(), "800".to_string()),
+        ftd::Weight::Bold => ("font-weight".to_string(), "700".to_string()),
+        ftd::Weight::SemiBold => ("font-weight".to_string(), "600".to_string()),
+        ftd::Weight::Medium => ("font-weight".to_string(), "500".to_string()),
+        ftd::Weight::Regular => ("font-weight".to_string(), "400".to_string()),
+        ftd::Weight::Light => ("font-weight".to_string(), "300".to_string()),
+        ftd::Weight::ExtraLight => ("font-weight".to_string(), "200".to_string()),
+        ftd::Weight::HairLine => ("font-weight".to_string(), "100".to_string()),
     }
 }

--- a/src/html.rs
+++ b/src/html.rs
@@ -707,6 +707,11 @@ impl ftd::Collector {
         if font.style.strike {
             styles.insert(s("text-decoration"), s("line-through"));
         }
+
+        if let Some(ref weight) = font.style.weight {
+            let (key, value) = style(weight);
+            styles.insert(s(key.as_str()), value);
+        }
         // if self.common.conditional_attribute.keys().any(|x| styles.keys().contains(&x)) {
         //     // todo: then don't make class
         //     // since font is not a conditional attribute this is not yet needed

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,7 @@ pub use ui::{
     Anchor, AttributeType, Code, Color, ColorValue, Column, Common, ConditionalAttribute,
     ConditionalValue, Container, Element, FontDisplay, GradientDirection, Grid, IFrame, IText,
     Image, ImageSrc, Input, Length, Markup, Markups, NamedFont, Overflow, Position, Region, Row,
-    Scene, Spacing, Style, Text, TextAlign, TextBlock, TextFormat, Type,
+    Scene, Spacing, Style, Text, TextAlign, TextBlock, TextFormat, Type, Weight,
 };
 pub use variable::{PropertyValue, TextSource, Value, Variable, VariableFlags};
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -2621,11 +2621,26 @@ pub struct ExternalFont {
     pub display: FontDisplay,
 }
 
+#[derive(serde::Deserialize, Debug, PartialEq, Clone, serde::Serialize)]
+#[serde(tag = "type")]
+pub enum Weight {
+    Heavy,
+    ExtraBold,
+    Bold,
+    SemiBold,
+    Medium,
+    Regular,
+    Light,
+    ExtraLight,
+    HairLine,
+}
+
 #[derive(serde::Deserialize, Debug, PartialEq, Default, Clone, serde::Serialize)]
 pub struct Style {
     pub italic: bool,
     pub underline: bool,
     pub strike: bool,
+    pub weight: Option<ftd::Weight>,
 }
 
 impl Style {
@@ -2634,6 +2649,7 @@ impl Style {
             italic: false,
             underline: false,
             strike: false,
+            weight: Default::default(),
         };
         let l = match l {
             Some(v) => v,
@@ -2645,6 +2661,15 @@ impl Style {
                 "italic" => s.italic = true,
                 "underline" => s.underline = true,
                 "strike" => s.strike = true,
+                "heavy" => s.weight = Some(ftd::Weight::Heavy),
+                "extra-bold" => s.weight = Some(ftd::Weight::ExtraBold),
+                "bold" => s.weight = Some(ftd::Weight::Bold),
+                "semi-bold" => s.weight = Some(ftd::Weight::SemiBold),
+                "medium" => s.weight = Some(ftd::Weight::Medium),
+                "regular" => s.weight = Some(ftd::Weight::Regular),
+                "light" => s.weight = Some(ftd::Weight::Light),
+                "extra-light" => s.weight = Some(ftd::Weight::ExtraLight),
+                "hairline" => s.weight = Some(ftd::Weight::HairLine),
                 t => return ftd::e2(format!("{} is not a valid style", t), doc_id, 0),
             }
         }


### PR DESCRIPTION
Now, the `style` property supports weight specifications too.

[Doc PR](https://github.com/FifthTry/ftd.dev/pull/22)
[Github Discussion](https://github.com/FifthTry/ftd/discussions/327)