### PR TITLE
strict empty line check prior to reading body

### DIFF
--- a/src/component.rs
+++ b/src/component.rs
@@ -2991,6 +2991,7 @@ mod test {
             -- string name: Amit
 
             -- ftd.text:
+
             $name
             ",
             (bag, main),

--- a/src/p1/parser.rs
+++ b/src/p1/parser.rs
@@ -116,7 +116,7 @@ impl State {
         // then throw error
         if !line.contains(':') {
             return Err(ftd::p1::Error::ParseError {
-                message: "start section body after a newline!!".to_string(),
+                message: format!("start section body \'{}\' after a newline!!", line),
                 doc_id: doc_id.to_string(),
                 line_number,
             });
@@ -154,7 +154,7 @@ impl State {
         // otherwise throw error
         if !line.contains(':') {
             return Err(ftd::p1::Error::ParseError {
-                message: "start sub-section body after a newline!!".to_string(),
+                message: format!("start sub-section body \'{}\' after a newline!!", line),
                 doc_id: doc_id.to_string(),
                 line_number,
             });
@@ -394,7 +394,7 @@ mod test {
         );
 
         p!(
-            "-- foo:\nhello world\n--- bar:",
+            "-- foo:\n\nhello world\n--- bar:",
             super::Section::with_name("foo")
                 .and_body("hello world")
                 .add_sub_section(super::SubSection::with_name("bar"))
@@ -405,9 +405,11 @@ mod test {
             indoc!(
                 "
             -- foo:
+
             body ho
             --- dodo:
             -- bar:
+
             bar body
             "
             ),
@@ -423,8 +425,10 @@ mod test {
             indoc!(
                 "
             -- foo:
+
             body ho
             -- bar:
+
             bar body
             --- dodo:
             "
@@ -441,8 +445,10 @@ mod test {
             indoc!(
                 "
             -- foo:
+
             body ho
             -- bar:
+
             bar body
             --- dodo:
             --- rat:
@@ -512,10 +518,13 @@ mod test {
             indoc!(
                 "
             -- foo:
+
             body ho
             -- bar:
+
             bar body
             --- dodo:
+
             hello
             "
             ),
@@ -528,7 +537,7 @@ mod test {
         );
 
         p!(
-            "-- foo:\nhello world\n--- bar:",
+            "-- foo:\n\nhello world\n--- bar:",
             super::Section::with_name("foo")
                 .and_body("hello world")
                 .add_sub_section(super::SubSection::with_name("bar"))
@@ -536,7 +545,7 @@ mod test {
         );
 
         p!(
-            "-- foo:\nhello world\n--- bar: foo",
+            "-- foo:\n\nhello world\n--- bar: foo",
             super::Section::with_name("foo")
                 .and_body("hello world")
                 .add_sub_section(super::SubSection::with_name("bar").and_caption("foo"))
@@ -607,12 +616,14 @@ mod test {
             ; yo
             b: ba
             ; yo
+
             bar body
             ; yo
             --- dodo:
             ; yo
             k: v
             ; yo
+
             hello
             ; yo
             "
@@ -645,9 +656,11 @@ mod test {
 
             -- bar:
             b: ba
+
             bar body
             --- dodo:
             k: v
+
             hello
             "
             ),
@@ -736,6 +749,7 @@ mod test {
             &indoc!(
                 "
                  -- markdown:
+
                  hello world is
 
                      not enough
@@ -848,7 +862,7 @@ mod test {
         );
 
         p!(
-            "-- foo:\nbody ho",
+            "-- foo:\n\nbody ho",
             super::Section::with_name("foo").and_body("body ho").list()
         );
 
@@ -856,8 +870,10 @@ mod test {
             indoc!(
                 "
             -- foo:
+
             body ho
             -- bar:
+
             bar body
             "
             ),

--- a/src/p1/parser.rs
+++ b/src/p1/parser.rs
@@ -917,4 +917,56 @@ mod test {
 
         f!("invalid", "foo:1 -> Expecting -- , found: invalid")
     }
+
+    #[test]
+    fn strict_body() {
+        // section body without headers
+        f!(
+            indoc!(
+                "-- some-section:
+                This is body
+                "
+            ),
+            "foo:2 -> start section body 'This is body' after a newline!!"
+        );
+
+        // section body with headers
+        f!(
+            indoc!(
+                "-- some-section:
+                h1: v1
+                This is body
+                "
+            ),
+            "foo:3 -> start section body 'This is body' after a newline!!"
+        );
+
+        // subsection body without headers
+        f!(
+            indoc!(
+                "-- some-section:
+                h1: val
+
+                --- some-sub-section:
+                This is body
+                "
+            ),
+            "foo:5 -> start sub-section body 'This is body' after a newline!!"
+        );
+
+        // subsection body with headers
+        f!(
+            indoc!(
+                "-- some-section:
+                h1: val
+
+                --- some-sub-section:
+                h2: val
+                h3: val
+                This is body
+                "
+            ),
+            "foo:7 -> start sub-section body 'This is body' after a newline!!"
+        );
+    }
 }

--- a/src/p2/interpreter.rs
+++ b/src/p2/interpreter.rs
@@ -17719,7 +17719,6 @@ mod test {
 
 
             -- ftd.column bar1:
-            ftd.ui
 
             -- ftd.column bar:
             string title:


### PR DESCRIPTION
- updated parser to do a strict check for an empty line before it starts reading body. 
- after reading all possible headers for current section/subsection, the parser will either 
    - start reading the next section/subsection 
    - or look for an empty line then change its state to read body
    
## After this change
```markdown
;; This is invalid will throw error
-- section: ... 
body

;; This is correct
-- section: ...

body
```