### PR TITLE
reworked duplicate header check on components

### DIFF
--- a/src/component.rs
+++ b/src/component.rs
@@ -2711,7 +2711,6 @@ pub(crate) fn default_arguments() -> std::collections::BTreeMap<String, ftd::p2:
         ftd::p2::Kind::decimal().into_optional(),
     );
     default_argument.insert("slot".to_string(), ftd::p2::Kind::string().into_optional());
-
     default_argument
 }
 
@@ -2967,6 +2966,27 @@ mod test {
                 line_number: 1,
                 ..Default::default()
             }
+        );
+    }
+
+    #[test]
+    fn duplicate_headers() {
+        // Repeated header definition with the same name (forbidden)
+        intf!(
+            "-- ftd.row foo:
+            caption name:
+            string name:
+            ",
+            "forbidden usage: 'name' is already used as header name/identifier !!, line_number: 3, doc: foo"
+        );
+
+        // Value assignment on the same header twice (not allowed)
+        intf!(
+            "-- ftd.text: Hello friends
+            align: center
+            align: left
+            ",
+            "forbidden usage: repeated usage of 'align' not allowed !!, line_number: 3, doc: foo"
         );
     }
 

--- a/src/component.rs
+++ b/src/component.rs
@@ -2756,12 +2756,8 @@ fn read_arguments(
     let mut args: std::collections::BTreeMap<String, ftd::p2::Kind> = Default::default();
     let mut inherits: Vec<String> = Default::default();
 
-    // dbg!(root);
-    // dbg!(&arguments.keys());
-    // dbg!(&root_arguments.keys());
     // contains parent arguments and current arguments
     let mut all_args = arguments.clone();
-    // dbg!(&all_args.keys());
 
     // Set of root arguments which are invoked once
     let mut root_args_set: std::collections::HashSet<String> = std::collections::HashSet::new();
@@ -2771,7 +2767,6 @@ fn read_arguments(
             continue;
         }
 
-        // dbg!(k, v);
         let var_data = match ftd::variable::VariableData::get_name_kind(
             k,
             doc,
@@ -2868,15 +2863,6 @@ fn read_arguments(
         args.insert(var_data.name.to_string(), kind.clone());
         all_args.insert(var_data.name.to_string(), kind);
     }
-
-    // dbg!(&root_arguments.keys());
-    // dbg!(&args.keys());
-    // println!("-------------------------------------------");
-    // dbg!(&all_args.keys());
-    // println!("Headers: ");
-    // for (_, k, v) in p1.0.iter() {
-    //     dbg!(k, v);
-    // }
 
     Ok((args, inherits))
 }

--- a/src/component.rs
+++ b/src/component.rs
@@ -2711,6 +2711,7 @@ pub(crate) fn default_arguments() -> std::collections::BTreeMap<String, ftd::p2:
         ftd::p2::Kind::decimal().into_optional(),
     );
     default_argument.insert("slot".to_string(), ftd::p2::Kind::string().into_optional());
+
     default_argument
 }
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -89,6 +89,37 @@ macro_rules! p {
     };
 }
 
+macro_rules! intf {
+    ($s:expr, $m: expr,) => {
+        int_fail!($s, $m)
+    };
+    ($s:expr, $m: expr) => {
+        match ftd::test::interpret("foo", indoc::indoc!($s), &ftd::p2::TestLibrary {}) {
+            Ok(some_value) => panic!("expected failure {:?}, found: {:?}", $m, some_value),
+            Err(e) => {
+                let expected_error = $m.trim();
+                let err_found = e.to_string();
+                let found = err_found.trim();
+                if expected_error != err_found {
+                    let patch = diffy::create_patch(expected_error, found);
+                    let f = diffy::PatchFormatter::new().with_color();
+                    print!(
+                        "{}",
+                        f.fmt_patch(&patch)
+                            .to_string()
+                            .replace("\\ No newline at end of file", "")
+                    );
+                    println!(
+                        "expected error:\n{}\nfound:\n{}\n",
+                        expected_error, err_found
+                    );
+                    panic!("test failed")
+                }
+            }
+        }
+    };
+}
+
 pub fn s(s: &str) -> String {
     s.to_string()
 }

--- a/src/test.rs
+++ b/src/test.rs
@@ -100,7 +100,7 @@ macro_rules! intf {
                 let expected_error = $m.trim();
                 let err_found = e.to_string();
                 let found = err_found.trim();
-                if expected_error != err_found {
+                if expected_error != found {
                     let patch = diffy::create_patch(expected_error, found);
                     let f = diffy::PatchFormatter::new().with_color();
                     print!(

--- a/src/test.rs
+++ b/src/test.rs
@@ -91,7 +91,7 @@ macro_rules! p {
 
 macro_rules! intf {
     ($s:expr, $m: expr,) => {
-        int_fail!($s, $m)
+        intf!($s, $m)
     };
     ($s:expr, $m: expr) => {
         match ftd::test::interpret("foo", indoc::indoc!($s), &ftd::p2::TestLibrary {}) {


### PR DESCRIPTION
- This PR is a continuation of an [old PR](https://github.com/FifthTry/ftd/pull/238) 
- issue - https://github.com/FifthTry/ftd/issues/181
- revamped the original PR

# Things added 

- added restriction on defining multiple headers with same name/identifier. 
```markdown
;; This is forbidden now
-- ftd.row foo:
caption name:
string name:
```
- assigning value mulitple times on the same header is restricted as well. Exception being the headers with `list` type
```markdown
;; This is not allowed as well
-- ftd.text: Hello friends
align: center
align: left
```
- added tests inside component.rs
- added a macro `intf!` for `interpreter failing` assertion similar to `f!`

# Note
- Tested these checks on other repos - `dotcom`, `doc-site`, `ftd.dev`, `fpm.dev`, `df`