### PR TITLE
removing font from code block

### DIFF
--- a/ftd.css
+++ b/ftd.css
@@ -127,7 +127,6 @@ ul {
 }
 
 .ft_md code {
-    font-size: 0.9rem;
     padding: 0.1rem 0.25rem;
     background-color: #f6f7f8;
     border-radius: 4px;


### PR DESCRIPTION
Need to remove font from default css for code. It breaks e.g. screen-shot below:


<img width="489" alt="image" src="https://user-images.githubusercontent.com/68585007/183646011-042f7cbe-6600-44b7-ad6f-4ed84eca9ba2.png">
