### PR TITLE
adding StuckOnTerm interpreter state for processing terms

### DIFF
--- a/src/component.rs
+++ b/src/component.rs
@@ -2664,6 +2664,7 @@ pub(crate) fn default_arguments() -> std::collections::BTreeMap<String, ftd::p2:
     let mut default_argument: std::collections::BTreeMap<String, ftd::p2::Kind> =
         Default::default();
     default_argument.insert("id".to_string(), ftd::p2::Kind::string().into_optional());
+    default_argument.insert("term".to_string(), ftd::p2::Kind::string().into_optional()); // temporary
     default_argument.insert("top".to_string(), ftd::p2::Kind::integer().into_optional());
     default_argument.insert(
         "bottom".to_string(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -161,6 +161,13 @@ pub fn interpret_helper(
                     },
                 )?;
             }
+            ftd::Interpreter::StuckOnTerm {
+                doc_index: index,
+                state: st,
+            } => {
+                // No config in ftd::ExampleLibrary ignoring processing terms for now
+                s = st.continue_after_processing_terms(None, index)?;
+            }
         }
     }
     Ok(document)

--- a/src/p2/element.rs
+++ b/src/p2/element.rs
@@ -435,6 +435,7 @@ fn common_arguments() -> Vec<(String, ftd::p2::Kind)> {
             ftd::p2::Kind::integer().into_optional(),
         ),
         ("id".to_string(), ftd::p2::Kind::string().into_optional()),
+        ("term".to_string(), ftd::p2::Kind::string().into_optional()), // temporary
         (
             "overflow-x".to_string(),
             ftd::p2::Kind::string().into_optional(),


### PR DESCRIPTION
- working on StuckOnTerm state for processing terms and to replace those with links. **(wip)** 

## TODO: 

This will be done in a seperate PR **(wip)**
- need to add `term` as `universal argument` 
- need to segregate `common` kernel arguments and `universal` component arguments (only in doc)
- need to refactor `common` arguments to `common kernel` arguments (only in doc)