### PR TITLE
fixed to_json test in sorted_json.rs

### DIFF
--- a/src/sorted_json.rs
+++ b/src/sorted_json.rs
@@ -106,7 +106,7 @@ mod tests {
     fn to_json() {
         a(serde_json::json! {null}, "null");
         a(serde_json::json! {1}, "1");
-        a(Value::Number(Number::from_f64(1.0).unwrap()), "1");
+        a(Value::Number(Number::from_f64(1.0).unwrap()), "1.0");
         a(
             Value::Number(Number::from_f64(-1.0002300e2).unwrap()),
             "-100.023",


### PR DESCRIPTION
We're taking f64, floating point value. Updating the same at the required place.


failures:

---- sorted_json::tests::to_json stdout ----
thread 'sorted_json::tests::to_json' panicked at 'assertion failed: `(left == right)`
  left: `"1.0"`