### PR TITLE
added ftd::Set<T> type definition

### DIFF
--- a/src/code.rs
+++ b/src/code.rs
@@ -13,7 +13,7 @@ lazy_static::lazy_static! {
         }
         builder.build()
     };
-    pub static ref KNOWN_EXTENSIONS: std::collections::HashSet<String> =
+    pub static ref KNOWN_EXTENSIONS: ftd::Set<String> =
         SS.syntaxes().iter().flat_map(|v| v.file_extensions.to_vec()).collect();
     pub static ref TS: syntect::highlighting::ThemeSet =
         syntect::highlighting::ThemeSet::load_defaults();

--- a/src/component.rs
+++ b/src/component.rs
@@ -2711,7 +2711,7 @@ fn read_arguments(
     let mut all_args = arguments.clone();
 
     // Set of root arguments which are invoked once
-    let mut root_args_set: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let mut root_args_set: ftd::Set<String> = ftd::Set::new();
     for (idx, (i, k, v)) in p1.0.iter().enumerate() {
         if (k.starts_with('$') && k.ends_with('$')) || k.starts_with('>') {
             // event and loop matches

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,6 +59,7 @@ pub fn html() -> &'static str {
 
 // #[cfg(test)]
 pub type Map<T> = std::collections::BTreeMap<String, T>;
+pub type Set<T> = std::collections::HashSet<T>;
 
 // #[cfg(not(test))]
 // pub type Map<T> = std::collections::HashMap<String, T>;


### PR DESCRIPTION
- [x] added type definition `ftd::Set<T>` for `std::collections::HashSet<T>` in lib.rs
- [x] refactored the original usage of `std::collections::HashSet` with `ftd::Set` throughout the code.