### PR TITLE
Adding universal attributes to all components (excluding term)

### DIFF
--- a/examples/universal-attributes.ftd
+++ b/examples/universal-attributes.ftd
@@ -1,0 +1,15 @@
+;; This previously worked when the arguments are locally defined
+-- ftd.text foo: $c
+optional string c:
+optional integer d:
+
+;; This works
+-- foo:
+c: xyz
+
+;; This works now since id is now a universal argument
+-- ftd.text t1: $id
+
+;; This works now (shows term and id)
+-- t1:
+id: some-id

--- a/src/component.rs
+++ b/src/component.rs
@@ -2417,14 +2417,6 @@ pub fn read_properties(
     is_reference: bool,
 ) -> ftd::p1::Result<ftd::Map<Property>> {
     let mut properties: ftd::Map<Property> = Default::default();
-    let root_arguments = {
-        let mut root_arguments = root_arguments.clone();
-        let universal_argument = universal_arguments();
-        for (key, arg) in universal_argument {
-            root_arguments.entry(key).or_insert(arg);
-        }
-        root_arguments
-    };
 
     for (name, kind) in root_arguments.iter() {
         if let Some(prop) = root_properties.get(name) {
@@ -2532,7 +2524,7 @@ pub fn read_properties(
                     value.as_str(),
                     Some(kind.to_owned()),
                     doc,
-                    &root_arguments,
+                    root_arguments,
                     Some(source.clone()),
                 )?,
                 Err(e) => return Err(e),
@@ -2713,6 +2705,10 @@ fn read_arguments(
     // contains parent arguments and current arguments
     let mut all_args = arguments.clone();
 
+    // Set of all universal arguments available to all components
+    let universal_arguments_set: std::collections::HashSet<String> =
+        universal_arguments().keys().cloned().collect();
+
     // Set of root arguments which are invoked once
     let mut root_args_set: std::collections::HashSet<String> = std::collections::HashSet::new();
     for (idx, (i, k, v)) in p1.0.iter().enumerate() {
@@ -2807,6 +2803,18 @@ fn read_arguments(
             return Err(ftd::p1::Error::ForbiddenUsage {
                 message: format!(
                     "\'{}\' is already used as header name/identifier !!",
+                    &var_data.name
+                ),
+                doc_id: doc.name.to_string(),
+                line_number: *i,
+            });
+        }
+
+        // checking if any universal argument is declared by the user (forbidden)
+        if universal_arguments_set.contains(&var_data.name) {
+            return Err(ftd::p1::Error::ForbiddenUsage {
+                message: format!(
+                    "redundant declaration of universal argument \'{}\' !!",
                     &var_data.name
                 ),
                 doc_id: doc.name.to_string(),

--- a/src/component.rs
+++ b/src/component.rs
@@ -1702,13 +1702,16 @@ impl Component {
         let name = var_data.name;
         let root = doc.resolve_name(p1.line_number, var_data.kind.as_str())?;
         let root_component = doc.get_component(p1.line_number, root.as_str())?;
-        let (arguments, inherits) = read_arguments(
+        let (mut arguments, inherits) = read_arguments(
             &p1.header,
             root.as_str(),
             &root_component.arguments,
             &Default::default(),
             doc,
         )?;
+
+        // Extend the local arguments with universal arguments
+        arguments.extend(universal_arguments());
 
         assert_no_extra_properties(
             p1.line_number,

--- a/src/variable.rs
+++ b/src/variable.rs
@@ -508,6 +508,14 @@ pub enum Value {
 }
 
 impl Value {
+    /// returns a default optional value from given kind
+    pub fn default_optional_value_from_kind(kind: ftd::p2::Kind) -> Self {
+        Value::Optional {
+            data: Box::new(None),
+            kind,
+        }
+    }
+
     pub fn inner_with_none(self) -> Self {
         match self {
             ftd::Value::Optional { data, kind } => data

--- a/tests/creating-a-tree.ftd
+++ b/tests/creating-a-tree.ftd
@@ -10,14 +10,14 @@ text: $text
 
 
 -- ftd.column table-of-content:
-string id:
+/string id:
 id: $id
 width: 300
 height: fill
 
 
 -- ftd.column parent:
-string id:
+/string id:
 caption name:
 optional boolean active:
 id: $id


### PR DESCRIPTION
- [x] added universal attributes to all components (id, top, align etc.)
[Doc PR](https://github.com/FifthTry/ftd.dev/pull/27) 
- [x] added check for redundant declaration of universal attribute by the user on components
- [x] fixed all ftd tests after these changes
- [x] example test file added `universal-attributes.ftd`
- [x] tested on the mentioned code
```markdown
-- ftd.text foo: $id

-- foo:
id: hello
``` 


- This is a continuation of an [Old PR](https://github.com/FifthTry/ftd/pull/364)

The idea of using `terms` for linking is dropped. Global `id` will be used for linking now
Refer [discussion](https://github.com/FifthTry/fpm/discussions/362)