### PR TITLE
adjustment to avoid redundant processing of comments

### DIFF
--- a/src/p2/interpreter.rs
+++ b/src/p2/interpreter.rs
@@ -49,8 +49,7 @@ impl InterpreterState {
 
         // Removing commented parts from the parsed document
         // Process this only once per parsed document no need to overdo it
-        if self.document_stack[l].processing_comments
-        {
+        if self.document_stack[l].processing_comments {
             self.document_stack[l].ignore_comments();
             self.document_stack[l].done_processing_comments();
         }


### PR DESCRIPTION
- adjusted to process/remove commented portions only once per parsed document
- no need to overdo this step at every `continue_()` iteration for the same document. 